### PR TITLE
Add "Drop" interaction prompt when carrying an object

### DIFF
--- a/COGITO/Components/PlayerInteractionComponent.gd
+++ b/COGITO/Components/PlayerInteractionComponent.gd
@@ -29,7 +29,10 @@ func _ready():
 		node.hide()
 
 func _process(_delta):
-	if interaction_raycast.is_colliding():
+	# when carrying object, disable all other prompts.
+	if carried_object:
+		emit_signal("interaction_prompt", "Drop")
+	elif interaction_raycast.is_colliding():
 		var interactable = interaction_raycast.get_collider()
 		is_reset = false
 		if interactable != null and interactable.has_method("interact"):
@@ -52,6 +55,11 @@ func _process(_delta):
 func _input(event):
 	if event.is_action_pressed("interact"):
 		
+		# if carrying an object, drop it.
+		if carried_object:
+			carried_object.throw(throw_power)
+			carried_object = null
+			
 		if interaction_raycast.is_colliding():
 			var interactable = interaction_raycast.get_collider()
 			if interactable.has_method("interact"):
@@ -65,13 +73,8 @@ func _input(event):
 				interactable.carry(self)
 	
 	# Wieldable primary Action Input
-	if !get_parent().is_movement_paused:	
-		# if carrying an object, drop it in response to action_primary.
-		if carried_object and event.is_action_pressed("action_primary"):
-			emit_signal("set_use_prompt", "")
-			carried_object.throw(throw_power)
-			carried_object = null
-		elif is_wielding and Input.is_action_just_pressed("action_primary"):
+	if !get_parent().is_movement_paused:
+		if is_wielding and Input.is_action_just_pressed("action_primary"):
 			attempt_action_primary()
 		
 		if is_wielding and Input.is_action_just_pressed("action_secondary"):

--- a/COGITO/Components/PlayerInteractionComponent.gd
+++ b/COGITO/Components/PlayerInteractionComponent.gd
@@ -63,15 +63,15 @@ func _input(event):
 					send_hint(null,"Can't carry an object while wielding.")
 			elif interactable.has_method("carry"):
 				interactable.carry(self)
-
-		else:
-			if carried_object != null and carried_object.has_method("carry"):
-				emit_signal("set_use_prompt", "")
-				carried_object.throw(throw_power)	
-
+	
 	# Wieldable primary Action Input
 	if !get_parent().is_movement_paused:	
-		if is_wielding and Input.is_action_just_pressed("action_primary"):
+		# if carrying an object, drop it in response to action_primary.
+		if carried_object and event.is_action_pressed("action_primary"):
+			emit_signal("set_use_prompt", "")
+			carried_object.throw(throw_power)
+			carried_object = null
+		elif is_wielding and Input.is_action_just_pressed("action_primary"):
 			attempt_action_primary()
 		
 		if is_wielding and Input.is_action_just_pressed("action_secondary"):


### PR DESCRIPTION
This provides a way to drop a carried item.

I noticed that there was no obvious way to drop the box once it was picked up. There was no support for setting a prompt while carrying an object. This provides a simple mechanism for that, by always sending the "interaction_prompt" signal while an object is being carried.