### PR TITLE
Update to input_helper v4.3.1

### DIFF
--- a/COGITO/Components/DynamicInputIcon.gd
+++ b/COGITO/Components/DynamicInputIcon.gd
@@ -50,18 +50,17 @@ func update_input_icon():
 		
 	else:
 		var joypad_input = InputHelper.get_joypad_input_for_action(action_name)
-		if joypad_input:
+		if joypad_input is InputEventJoypadButton:
 			#print("DynamicInputIcon: Action=", action_name, ". Joypad btn=", joypad_input.button_index)
 			set_texture(gamepad_icons)
 			frame = joypad_input.button_index
 			
-		var joypad_motion = InputHelper.get_joypad_motion_for_action(action_name)
-		if joypad_motion:
+		elif joypad_input is InputEventJoypadMotion:
 			#print("DynamicInputIcon: Action=", action_name, ". Joypad motion=", joypad_motion.axis)
 			set_texture(gamepad_icons)
-			if joypad_motion.axis == 5:
+			if joypad_input.axis == 5:
 				frame = 18 #Sets icon to RT
-			if joypad_motion.axis == 4:
+			if joypad_input.axis == 4:
 				frame = 17 #Sets icon to LT
 
 

--- a/addons/input_helper/InputHelper.cs
+++ b/addons/input_helper/InputHelper.cs
@@ -130,31 +130,31 @@ namespace NathanHoad
 
     #region Joypad
 
-    public static Array<InputEventJoypadButton> GetJoypadInputsForAction(string action)
+    public static Array<InputEvent> GetJoypadInputsForAction(string action)
     {
-      return (Array<InputEventJoypadButton>)Instance.Call("get_joypad_inputs_for_action", action);
+      return (Array<InputEvent>)Instance.Call("get_joypad_inputs_for_action", action);
     }
 
 
     public static InputEvent GetJoypadInputForAction(string action)
     {
-      return (InputEventJoypadButton)Instance.Call("get_joypad_input_for_action", action);
+      return (InputEvent)Instance.Call("get_joypad_input_for_action", action);
     }
 
 
-    public static void SetJoypadInputForAction(string action, InputEventJoypadButton input, bool swapIfTaken = true)
+    public static void SetJoypadInputForAction(string action, InputEvent input, bool swapIfTaken = true)
     {
       Instance.Call("set_joypad_input_for_action", action, input, swapIfTaken);
     }
 
 
-    public static void ReplaceJoypadInputForAction(string action, InputEventJoypadButton currentInput, InputEventJoypadButton input, bool swapIfTaken = true)
+    public static void ReplaceJoypadInputForAction(string action, InputEvent currentInput, InputEvent input, bool swapIfTaken = true)
     {
       Instance.Call("replace_joypad_input_for_action", action, currentInput, input, swapIfTaken);
     }
 
 
-    public static void ReplaceJoypadInputAtIndex(string action, int index, InputEventJoypadButton input, bool swapIfTaken = true)
+    public static void ReplaceJoypadInputAtIndex(string action, int index, InputEvent input, bool swapIfTaken = true)
     {
       Instance.Call("replace_joypad_input_at_index", action, index, input, swapIfTaken);
     }

--- a/addons/input_helper/plugin.cfg
+++ b/addons/input_helper/plugin.cfg
@@ -3,5 +3,5 @@
 name="Input Helper"
 description="Detect which input device the player is using and manage input actions"
 author="Nathan Hoad"
-version="4.2.2"
+version="4.3.1"
 script="plugin.gd"


### PR DESCRIPTION
This removes get_joypad_motions_for_action(), instead get_joypad_inputs_for_action() returns both
InputEventJoypadButton and InputEventJoypadMotion events.

Change update_input_icon() to handle both InputEventJoypadButton and InputEventJoypadButton result types.