### PR TITLE
Refactor test motion

### DIFF
--- a/COGITO/Scripts/ladder_area.gd
+++ b/COGITO/Scripts/ladder_area.gd
@@ -7,11 +7,11 @@ func _ready():
 
 func _on_body_entered(body):
 	if body.is_in_group("Player"):
-		print("Entered ladder")
+		#print("Entered ladder")
 		body.on_ladder = true
 
 
 func _on_body_exited(body):
 	if body.is_in_group("Player"):
-		print("Exited ladder")
+		#print("Exited ladder")
 		body.on_ladder = false

--- a/COGITO/Scripts/player.gd
+++ b/COGITO/Scripts/player.gd
@@ -306,7 +306,7 @@ func _process_on_ladder(_delta):
 	if jump:
 		velocity += look_vector * Vector3(JUMP_VELOCITY, JUMP_VELOCITY, JUMP_VELOCITY)
 	
-	print("Input_dir:", input_dir, ". direction:", direction)
+	# print("Input_dir:", input_dir, ". direction:", direction)
 	move_and_slide()
 	
 	#Step off ladder when on ground


### PR DESCRIPTION
Cache allocations of params and test_motion_result

Instead of allocating these on each call to _physics_process(),
allocate once using @onready variables.

Also refactor calls to PhysicsServer3D.body_test_motion() to call
a helper function, test_motion() to make the code smaller.