### PR TITLE
Improving jump functionality

### DIFF
--- a/COGITO/PrefabScenes/player.tscn
+++ b/COGITO/PrefabScenes/player.tscn
@@ -129,5 +129,9 @@ start_sanity = 30.0
 
 [node name="BrightnessComponent" parent="." instance=ExtResource("9_x4tef")]
 
+[node name="JumpCooldownTimer" type="Timer" parent="."]
+wait_time = 0.2
+one_shot = true
+
 [connection signal="animation_finished" from="Neck/Head/Eyes/AnimationPlayer" to="." method="_on_animation_player_animation_finished"]
 [connection signal="timeout" from="SlidingTimer" to="." method="_on_sliding_timer_timeout"]

--- a/COGITO/PrefabScenes/player.tscn
+++ b/COGITO/PrefabScenes/player.tscn
@@ -130,7 +130,7 @@ start_sanity = 30.0
 [node name="BrightnessComponent" parent="." instance=ExtResource("9_x4tef")]
 
 [node name="JumpCooldownTimer" type="Timer" parent="."]
-wait_time = 0.2
+wait_time = 0.5
 one_shot = true
 
 [connection signal="animation_finished" from="Neck/Head/Eyes/AnimationPlayer" to="." method="_on_animation_player_animation_finished"]

--- a/COGITO/Scripts/player.gd
+++ b/COGITO/Scripts/player.gd
@@ -503,29 +503,31 @@ func _physics_process(delta):
 		# Taking fall damage
 		if fall_damage > 0 and last_velocity.y <= fall_damage_threshold:
 			health_component.subtract(fall_damage)
-	
+
 	if Input.is_action_pressed("jump") and !is_movement_paused and is_on_floor():
-		snap = Vector3.ZERO
-		is_falling = true
-		# If Stamina Component is used, this checks if there's enough stamina to jump and denies it if not.
-		if is_using_stamina and stamina_component.current_stamina >= stamina_component.jump_exhaustion:
-			decrease_attribute("stamina",stamina_component.jump_exhaustion)
+		var doesnt_need_stamina = not is_using_stamina or stamina_component.current_stamina >= stamina_component.jump_exhaustion
+		
+		if doesnt_need_stamina:
+			# If Stamina Component is used, this checks if there's enough stamina to jump and denies it if not.
+			if is_using_stamina:
+				decrease_attribute("stamina",stamina_component.jump_exhaustion)
+			snap = Vector3.ZERO
+			is_falling = true
+				
+			animationPlayer.play("jump")
+			Audio.play_sound(jump_sound)
+			if !sliding_timer.is_stopped():
+				velocity.y = JUMP_VELOCITY * 1.5
+				sliding_timer.stop()
+			else:
+				velocity.y = JUMP_VELOCITY
+			if is_sprinting:
+				bunny_hop_speed += BUNNY_HOP_ACCELERATION
+			else:
+				bunny_hop_speed = SPRINTING_SPEED
 		else:
 			print("Not enough stamina to jump.")
-			return
-			
-		animationPlayer.play("jump")
-		Audio.play_sound(jump_sound)
-		if !sliding_timer.is_stopped():
-			velocity.y = JUMP_VELOCITY * 1.5
-			sliding_timer.stop()
-		else:
-			velocity.y = JUMP_VELOCITY
-		if is_sprinting:
-			bunny_hop_speed += BUNNY_HOP_ACCELERATION
-		else:
-			bunny_hop_speed = SPRINTING_SPEED
-	
+
 	if sliding_timer.is_stopped():
 		if is_on_floor():
 			direction = lerp(

--- a/COGITO/Scripts/player.gd
+++ b/COGITO/Scripts/player.gd
@@ -538,7 +538,7 @@ func _physics_process(delta):
 				#temporarily switch colliders to process jump correctly
 				standing_collision_shape.disabled = false
 				crouching_collision_shape.disabled = true
-		else:
+		elif not doesnt_need_stamina:
 			print("Not enough stamina to jump.")
 
 	if sliding_timer.is_stopped():

--- a/COGITO/Scripts/player.gd
+++ b/COGITO/Scripts/player.gd
@@ -57,6 +57,7 @@ signal player_state_loaded()
 @export var SPRINTING_SPEED = 8.0
 @export var CROUCHING_SPEED = 3.0
 @export var CROUCHING_DEPTH = -0.9
+@export var CAN_CROUCH_JUMP = true
 @export var MOUSE_SENS = 0.25
 @export var LERP_SPEED = 10.0
 @export var AIR_LERP_SPEED = 6.0
@@ -506,10 +507,11 @@ func _physics_process(delta):
 			health_component.subtract(fall_damage)
 	
 	if Input.is_action_pressed("jump") and !is_movement_paused and is_on_floor() and jump_timer.is_stopped():
-		var doesnt_need_stamina = not is_using_stamina or stamina_component.current_stamina >= stamina_component.jump_exhaustion
 		jump_timer.start() # prevent spam
+		var doesnt_need_stamina = not is_using_stamina or stamina_component.current_stamina >= stamina_component.jump_exhaustion
+		var crouch_jump = not is_crouching or CAN_CROUCH_JUMP
 		
-		if doesnt_need_stamina:
+		if doesnt_need_stamina and crouch_jump:
 			# If Stamina Component is used, this checks if there's enough stamina to jump and denies it if not.
 			if is_using_stamina:
 				decrease_attribute("stamina",stamina_component.jump_exhaustion)
@@ -531,6 +533,11 @@ func _physics_process(delta):
 				bunny_hop_speed += BUNNY_HOP_ACCELERATION
 			else:
 				bunny_hop_speed = SPRINTING_SPEED
+			
+			if is_crouching:
+				#temporarily switch colliders to process jump correctly
+				standing_collision_shape.disabled = false
+				crouching_collision_shape.disabled = true
 		else:
 			print("Not enough stamina to jump.")
 

--- a/COGITO/Scripts/player.gd
+++ b/COGITO/Scripts/player.gd
@@ -525,9 +525,15 @@ func _physics_process(delta):
 				sliding_timer.stop()
 			else:
 				velocity.y = JUMP_VELOCITY
-				
-			var platformY = get_platform_velocity().y # inherit any platform upwards velocity
-			velocity.y += platformY
+			
+			if platform_on_leave != PLATFORM_ON_LEAVE_DO_NOTHING:
+				var platform_velocity = get_platform_velocity()
+				# TODO: Make PLATFORM_ON_LEAVE_ADD_VELOCITY work... somehow. 
+				# Velocity X and Z gets overridden later, so you immediately lose the velocity
+				if PLATFORM_ON_LEAVE_ADD_UPWARD_VELOCITY:
+					platform_velocity.x = 0
+					platform_velocity.z = 0
+				velocity += platform_velocity
 			
 			if is_sprinting:
 				bunny_hop_speed += BUNNY_HOP_ACCELERATION


### PR DESCRIPTION
 - FEATURE: New crouch jumping toggle on the Player script ([6d28627](https://github.com/Phazorknight/Cogito/pull/69/commits/6d28627fccc63b8fe7d8365dc0e0a13e763ef24c))
 - FEATURE/BUGFIX: Jump now has a cooldown timer, allowing you to still "hold" jump to jump over and over again without needing to re-press, but it won't spam it in such a way that will cause you to burn your stamina or other similar effects. The timer is currently set to half a second ([27c8843](https://github.com/Phazorknight/Cogito/pull/69/commits/27c8843daf525e6f204d095902b15367ac4f4ed5))
- FEATURE/BUGFIX: When jumping off a moving platform (i.e. is recognized by 'get_platform_velocity()'), the jump will inherit the upwards velocity of the platform as well.([27c8843](https://github.com/Phazorknight/Cogito/pull/69/commits/27c8843daf525e6f204d095902b15367ac4f4ed5))
- BUGFIX: Jump no longer 'locks' the player unless they successfully perform a jump ([6b4bc96](https://github.com/Phazorknight/Cogito/pull/69/commits/6b4bc9607631d465f0bc60e6947cf200f175d36a))
- BUGFIX: Crouch jumping now works ([6d28627](https://github.com/Phazorknight/Cogito/pull/69/commits/6d28627fccc63b8fe7d8365dc0e0a13e763ef24c))

Issue resolutions: 
Fixes #68: Now when you jump off the moving platform, you inherit its upwards velocity. Additionally, jumping doesn't get spammed anymore.
Fixes #59: You can now disable crouch jumping, and by changing the collider on a crouch jump, crouch jumping now works. I haven't refined it any more than that.