### PR TITLE
Improve in-air behavior for crouch and slide jumps

### DIFF
--- a/COGITO/Scripts/player.gd
+++ b/COGITO/Scripts/player.gd
@@ -440,8 +440,12 @@ func _physics_process(delta):
 	else:
 		head.position.y = lerp(head.position.y, 0.0, delta * LERP_SPEED)
 		carryable_position.position.y = lerp(carryable_position.position.y, initial_carryable_height, delta * LERP_SPEED)
-		standing_collision_shape.disabled = false
-		crouching_collision_shape.disabled = true
+		if head.position.y < CROUCHING_DEPTH/4:
+			crouching_collision_shape.disabled = false
+			standing_collision_shape.disabled = true
+		else:
+			standing_collision_shape.disabled = false
+			crouching_collision_shape.disabled = true
 		sliding_timer.stop()
 		# Prevent sprinting if player is out of stamina.
 		if Input.is_action_pressed("sprint") and is_using_stamina and stamina_component.current_stamina > 0:

--- a/COGITO/Scripts/player.gd
+++ b/COGITO/Scripts/player.gd
@@ -69,6 +69,7 @@ var is_showing_ui : bool
 @export var AIR_LERP_SPEED = 6.0
 @export var FREE_LOOK_TILT_AMOUNT = 5.0
 @export var SLIDING_SPEED = 5.0
+@export var SLIDE_JUMP_MOD = 1.5
 
 @export_enum("Minimal:1", "Average:3", "Full:7") var HEADBOBBLE : int
 var WIGGLE_ON_WALKING_SPEED = 14.0
@@ -554,7 +555,7 @@ func _physics_process(delta):
 			Audio.play_sound(jump_sound)
 			if !sliding_timer.is_stopped():
 				# if we're doing a slide jump, use our standard JUMP_VELOCITY
-				velocity.y = JUMP_VELOCITY * 1.5
+				velocity.y = JUMP_VELOCITY * SLIDE_JUMP_MOD
 				jumped_from_slide = true
 				sliding_timer.stop()
 			else:

--- a/COGITO/Scripts/player.gd
+++ b/COGITO/Scripts/player.gd
@@ -553,6 +553,7 @@ func _physics_process(delta):
 			animationPlayer.play("jump")
 			Audio.play_sound(jump_sound)
 			if !sliding_timer.is_stopped():
+				# if we're doing a slide jump, use our standard JUMP_VELOCITY
 				velocity.y = JUMP_VELOCITY * 1.5
 				jumped_from_slide = true
 				sliding_timer.stop()

--- a/COGITO/Scripts/player.gd
+++ b/COGITO/Scripts/player.gd
@@ -416,7 +416,7 @@ func _physics_process(delta):
 		# if we're jumping from a pure crouch (no slide), then we want to lock our crouch state
 		crouched_jump = is_crouching and not jumped_from_slide
 	
-	if crouched_jump or (not jumped_from_slide and Input.is_action_pressed("crouch") and !is_movement_paused or crouch_raycast.is_colliding()):
+	if crouched_jump or (not jumped_from_slide and is_on_floor() and Input.is_action_pressed("crouch") and !is_movement_paused or crouch_raycast.is_colliding()):
 		# should we be sliding?
 		if is_sprinting and input_dir != Vector2.ZERO and is_on_floor():
 			sliding_timer.start()

--- a/COGITO/Scripts/player.gd
+++ b/COGITO/Scripts/player.gd
@@ -441,6 +441,7 @@ func _physics_process(delta):
 		head.position.y = lerp(head.position.y, 0.0, delta * LERP_SPEED)
 		carryable_position.position.y = lerp(carryable_position.position.y, initial_carryable_height, delta * LERP_SPEED)
 		if head.position.y < CROUCHING_DEPTH/4:
+			# still transitioning from state
 			crouching_collision_shape.disabled = false
 			standing_collision_shape.disabled = true
 		else:
@@ -736,7 +737,10 @@ func _physics_process(delta):
 	
 	# FOOTSTEP SOUNDS SYSTEM = CHECK IF ON GROUND AND MOVING
 	if is_on_floor() and velocity.length() >= 0.2:
-		if footstep_timer.time_left <= 0:
+		if not sliding_timer.is_stopped():
+			# TODO: Add slide sound effects. For now, mute it
+			pass
+		elif footstep_timer.time_left <= 0:
 			#dynamic volume for footsteps
 			if is_walking:
 				footstep_player.volume_db = walk_volume_db


### PR DESCRIPTION
This is a little prescriptive to what I found "feels right", but in response to #79, I've modified how crouch and slide jumps feel and look.

In #79, @ksjfhor found that un-crouching mid-air would look as though there's a sudden upwards velocity to exactly where you'd expect the jump to be if you had done it standing. It is merely a visual effect from the camera moving from the crouched height to the standing height, the jump is functionally exactly the same. The only thing that changes is the camera height, and the collision to make collisions consistent with what the player is seeing.

I personally find this behavior makes for consistent functionality both as a player and as a dev trying to find the right game feel. When crouch jumping, the characters *feet* comes off the ground by exactly the same amount whether crouched or standing. 

To address the visual jitter, I made it so you can't change your standing/crouching state visually whilst jumping. This feels a little prescriptivist, but I think is the neatest solution for right now with minimal compromise in terms of actual game functionality and feel. If you're making a parkour game however, you may find you need to alter this behavior with a custom solution to resolve this, but that likely would've been the case anyways.

I also changed the in-air behavior. If you're crouched and in-air, you will consistently have the crouch movement speed, unless you're jumping from a slide. If you're slide jumping, your character will largely be registered as being in the "standing" state, which also includes having the camera in the standing state. 

I've added 2 parameters for devs to be able to dial in their game feel:
`CROUCH_JUMP_VELOCITY` - what force your jump should have if crouch jumping
`SLIDE_JUMP_MOD` - modifier to how strong your jump is coming from a slide