### PR TITLE
QOL: Add keypad shortcuts so users can type with keyboard

### DIFF
--- a/COGITO/InventoryPD/UiScenes/hot_bar_inventory.gd
+++ b/COGITO/InventoryPD/UiScenes/hot_bar_inventory.gd
@@ -6,7 +6,7 @@ const Slot = preload("res://COGITO/InventoryPD/UiScenes/Slot.tscn")
 @onready var h_box_container = $MarginContainer/VBoxContainer/TopRow
 
 
-func _input(event):
+func _unhandled_input(event):
 	# Handles Gamepad Hotbar input
 	if not visible:
 		return

--- a/COGITO/PrefabScenes/keypad_prefab.tscn
+++ b/COGITO/PrefabScenes/keypad_prefab.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://i4rqcx7lyrfd"]
+[gd_scene load_steps=50 format=3 uid="uid://i4rqcx7lyrfd"]
 
 [ext_resource type="Script" path="res://COGITO/Scripts/Cogito_Keypad.gd" id="1_iwk1o"]
 [ext_resource type="AudioStream" uid="uid://cn3yrske0mwlf" path="res://COGITO/Assets/Audio/Kenney/jingles-pizzicato_14.ogg" id="2_5i70k"]
@@ -28,6 +28,133 @@ size = Vector3(0.3, 0.06, 0.5)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_sqlw7"]
 bg_color = Color(1, 1, 1, 1)
+
+[sub_resource type="InputEventKey" id="InputEventKey_2e4oq"]
+device = -1
+keycode = 49
+unicode = 49
+
+[sub_resource type="InputEventKey" id="InputEventKey_tyspr"]
+keycode = 4194439
+
+[sub_resource type="Shortcut" id="Shortcut_wq2ju"]
+events = [SubResource("InputEventKey_2e4oq"), SubResource("InputEventKey_tyspr")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_bvlui"]
+device = -1
+keycode = 50
+unicode = 50
+
+[sub_resource type="InputEventKey" id="InputEventKey_xd6rk"]
+keycode = 4194440
+
+[sub_resource type="Shortcut" id="Shortcut_1s2p8"]
+events = [SubResource("InputEventKey_bvlui"), SubResource("InputEventKey_xd6rk")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_18fcb"]
+device = -1
+keycode = 51
+unicode = 51
+
+[sub_resource type="InputEventKey" id="InputEventKey_qwqix"]
+keycode = 4194441
+
+[sub_resource type="Shortcut" id="Shortcut_yqbel"]
+events = [SubResource("InputEventKey_18fcb"), SubResource("InputEventKey_qwqix")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_ehlrf"]
+device = -1
+keycode = 52
+unicode = 52
+
+[sub_resource type="InputEventKey" id="InputEventKey_e2wyl"]
+keycode = 4194442
+
+[sub_resource type="Shortcut" id="Shortcut_ik0et"]
+events = [SubResource("InputEventKey_ehlrf"), SubResource("InputEventKey_e2wyl")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_0i8nx"]
+device = -1
+keycode = 53
+unicode = 53
+
+[sub_resource type="InputEventKey" id="InputEventKey_c6hnb"]
+keycode = 4194443
+
+[sub_resource type="Shortcut" id="Shortcut_0j1pw"]
+events = [SubResource("InputEventKey_0i8nx"), SubResource("InputEventKey_c6hnb")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_e5ehg"]
+device = -1
+keycode = 54
+unicode = 54
+
+[sub_resource type="InputEventKey" id="InputEventKey_xfh20"]
+keycode = 4194444
+
+[sub_resource type="Shortcut" id="Shortcut_ekah0"]
+events = [SubResource("InputEventKey_e5ehg"), SubResource("InputEventKey_xfh20")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_8pe7w"]
+device = -1
+keycode = 55
+unicode = 55
+
+[sub_resource type="InputEventKey" id="InputEventKey_tar3q"]
+keycode = 4194445
+
+[sub_resource type="Shortcut" id="Shortcut_w80ll"]
+events = [SubResource("InputEventKey_8pe7w"), SubResource("InputEventKey_tar3q")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_eaxnm"]
+device = -1
+keycode = 56
+unicode = 56
+
+[sub_resource type="InputEventKey" id="InputEventKey_0lmq7"]
+keycode = 4194446
+
+[sub_resource type="Shortcut" id="Shortcut_32785"]
+events = [SubResource("InputEventKey_eaxnm"), SubResource("InputEventKey_0lmq7")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_1ro47"]
+device = -1
+keycode = 57
+unicode = 57
+
+[sub_resource type="InputEventKey" id="InputEventKey_n7u6p"]
+keycode = 4194447
+
+[sub_resource type="Shortcut" id="Shortcut_cujgu"]
+events = [SubResource("InputEventKey_1ro47"), SubResource("InputEventKey_n7u6p")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_mpn15"]
+device = -1
+keycode = 4194308
+
+[sub_resource type="InputEventJoypadButton" id="InputEventJoypadButton_u520m"]
+button_index = 1
+
+[sub_resource type="Shortcut" id="Shortcut_pdj7m"]
+events = [SubResource("InputEventKey_mpn15"), SubResource("InputEventJoypadButton_u520m")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_se7no"]
+keycode = 48
+physical_keycode = 48
+key_label = 48
+
+[sub_resource type="InputEventKey" id="InputEventKey_klrbc"]
+keycode = 4194438
+
+[sub_resource type="Shortcut" id="Shortcut_bv5yc"]
+events = [SubResource("InputEventKey_se7no"), SubResource("InputEventKey_klrbc")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_rrpqx"]
+device = -1
+keycode = 4194309
+
+[sub_resource type="Shortcut" id="Shortcut_1xuph"]
+events = [SubResource("InputEventKey_rrpqx")]
 
 [node name="Keypad" type="StaticBody3D"]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, 0)
@@ -183,6 +310,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_font_sizes/font_size = 28
+shortcut = SubResource("Shortcut_wq2ju")
 text = "1"
 script = ExtResource("6_ebwkh")
 
@@ -192,6 +320,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_font_sizes/font_size = 28
+shortcut = SubResource("Shortcut_1s2p8")
 text = "2"
 script = ExtResource("6_ebwkh")
 
@@ -201,6 +330,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_font_sizes/font_size = 28
+shortcut = SubResource("Shortcut_yqbel")
 text = "3"
 script = ExtResource("6_ebwkh")
 
@@ -210,6 +340,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_font_sizes/font_size = 28
+shortcut = SubResource("Shortcut_ik0et")
 text = "4"
 script = ExtResource("6_ebwkh")
 
@@ -219,6 +350,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_font_sizes/font_size = 28
+shortcut = SubResource("Shortcut_0j1pw")
 text = "5"
 script = ExtResource("6_ebwkh")
 
@@ -228,6 +360,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_font_sizes/font_size = 28
+shortcut = SubResource("Shortcut_ekah0")
 text = "6"
 script = ExtResource("6_ebwkh")
 
@@ -237,6 +370,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_font_sizes/font_size = 28
+shortcut = SubResource("Shortcut_w80ll")
 text = "7"
 script = ExtResource("6_ebwkh")
 
@@ -246,6 +380,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_font_sizes/font_size = 28
+shortcut = SubResource("Shortcut_32785")
 text = "8"
 script = ExtResource("6_ebwkh")
 
@@ -255,6 +390,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_font_sizes/font_size = 28
+shortcut = SubResource("Shortcut_cujgu")
 text = "9"
 script = ExtResource("6_ebwkh")
 
@@ -264,6 +400,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_font_sizes/font_size = 28
+shortcut = SubResource("Shortcut_pdj7m")
 text = "C"
 script = ExtResource("6_ebwkh")
 
@@ -273,6 +410,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_font_sizes/font_size = 28
+shortcut = SubResource("Shortcut_bv5yc")
 text = "0"
 script = ExtResource("6_ebwkh")
 
@@ -282,6 +420,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_font_sizes/font_size = 28
+shortcut = SubResource("Shortcut_1xuph")
 text = "E"
 script = ExtResource("6_ebwkh")
 

--- a/COGITO/PrefabScenes/keypad_prefab.tscn
+++ b/COGITO/PrefabScenes/keypad_prefab.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=50 format=3 uid="uid://i4rqcx7lyrfd"]
+[gd_scene load_steps=48 format=3 uid="uid://i4rqcx7lyrfd"]
 
 [ext_resource type="Script" path="res://COGITO/Scripts/Cogito_Keypad.gd" id="1_iwk1o"]
 [ext_resource type="AudioStream" uid="uid://cn3yrske0mwlf" path="res://COGITO/Assets/Audio/Kenney/jingles-pizzicato_14.ogg" id="2_5i70k"]
@@ -149,13 +149,6 @@ keycode = 4194438
 [sub_resource type="Shortcut" id="Shortcut_bv5yc"]
 events = [SubResource("InputEventKey_se7no"), SubResource("InputEventKey_klrbc")]
 
-[sub_resource type="InputEventKey" id="InputEventKey_rrpqx"]
-device = -1
-keycode = 4194309
-
-[sub_resource type="Shortcut" id="Shortcut_1xuph"]
-events = [SubResource("InputEventKey_rrpqx")]
-
 [node name="Keypad" type="StaticBody3D"]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, 0)
 collision_layer = 3
@@ -304,125 +297,137 @@ theme_override_constants/separation = 10
 layout_mode = 2
 columns = 3
 
-[node name="1" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer"]
+[node name="1" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer" node_paths=PackedStringArray("shortcut_context")]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+shortcut_context = NodePath("..")
 theme_override_font_sizes/font_size = 28
 shortcut = SubResource("Shortcut_wq2ju")
 text = "1"
 script = ExtResource("6_ebwkh")
 
-[node name="2" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer"]
+[node name="2" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer" node_paths=PackedStringArray("shortcut_context")]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+shortcut_context = NodePath("..")
 theme_override_font_sizes/font_size = 28
 shortcut = SubResource("Shortcut_1s2p8")
 text = "2"
 script = ExtResource("6_ebwkh")
 
-[node name="3" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer"]
+[node name="3" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer" node_paths=PackedStringArray("shortcut_context")]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+shortcut_context = NodePath("..")
 theme_override_font_sizes/font_size = 28
 shortcut = SubResource("Shortcut_yqbel")
 text = "3"
 script = ExtResource("6_ebwkh")
 
-[node name="4" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer"]
+[node name="4" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer" node_paths=PackedStringArray("shortcut_context")]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+shortcut_context = NodePath("..")
 theme_override_font_sizes/font_size = 28
 shortcut = SubResource("Shortcut_ik0et")
 text = "4"
 script = ExtResource("6_ebwkh")
 
-[node name="5" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer"]
+[node name="5" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer" node_paths=PackedStringArray("shortcut_context")]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+shortcut_context = NodePath("..")
 theme_override_font_sizes/font_size = 28
 shortcut = SubResource("Shortcut_0j1pw")
 text = "5"
 script = ExtResource("6_ebwkh")
 
-[node name="6" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer"]
+[node name="6" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer" node_paths=PackedStringArray("shortcut_context")]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+shortcut_context = NodePath("..")
 theme_override_font_sizes/font_size = 28
 shortcut = SubResource("Shortcut_ekah0")
 text = "6"
 script = ExtResource("6_ebwkh")
 
-[node name="7" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer"]
+[node name="7" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer" node_paths=PackedStringArray("shortcut_context")]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+shortcut_context = NodePath("..")
 theme_override_font_sizes/font_size = 28
 shortcut = SubResource("Shortcut_w80ll")
 text = "7"
 script = ExtResource("6_ebwkh")
 
-[node name="8" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer"]
+[node name="8" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer" node_paths=PackedStringArray("shortcut_context")]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+shortcut_context = NodePath("..")
 theme_override_font_sizes/font_size = 28
 shortcut = SubResource("Shortcut_32785")
 text = "8"
 script = ExtResource("6_ebwkh")
 
-[node name="9" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer"]
+[node name="9" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer" node_paths=PackedStringArray("shortcut_context")]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+shortcut_context = NodePath("..")
 theme_override_font_sizes/font_size = 28
 shortcut = SubResource("Shortcut_cujgu")
 text = "9"
 script = ExtResource("6_ebwkh")
 
-[node name="Clear" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer"]
+[node name="Clear" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer" node_paths=PackedStringArray("shortcut_context")]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+shortcut_context = NodePath("..")
 theme_override_font_sizes/font_size = 28
 shortcut = SubResource("Shortcut_pdj7m")
 text = "C"
 script = ExtResource("6_ebwkh")
 
-[node name="0" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer"]
+[node name="0" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer" node_paths=PackedStringArray("shortcut_context")]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+shortcut_context = NodePath("..")
 theme_override_font_sizes/font_size = 28
 shortcut = SubResource("Shortcut_bv5yc")
 text = "0"
 script = ExtResource("6_ebwkh")
 
-[node name="Enter" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer"]
+[node name="Enter" type="Button" parent="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer" node_paths=PackedStringArray("shortcut_context")]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+shortcut_context = NodePath("..")
 theme_override_font_sizes/font_size = 28
-shortcut = SubResource("Shortcut_1xuph")
 text = "E"
 script = ExtResource("6_ebwkh")
+accepts_contextual_enter = true
 
 [connection signal="pressed_string" from="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer/1" to="." method="_on_button_received"]
 [connection signal="pressed_string" from="KeypadUi/Bindings/ScrollContainer/VBoxContainer/GridContainer/2" to="." method="_on_button_received"]

--- a/COGITO/Scripts/Cogito_Keypad.gd
+++ b/COGITO/Scripts/Cogito_Keypad.gd
@@ -47,6 +47,8 @@ var interaction_nodes : Array[Node]
 var entered_code: String
 var player_interaction_component
 
+var in_focus : bool
+
 
 func _ready():
 	code_display.text = ""
@@ -62,7 +64,10 @@ func _ready():
 		interaction_text = interaction_text_when_locked
 		
 	object_state_updated.emit(interaction_text)
+	get_viewport().connect("gui_focus_changed", self._on_focus_changed)
 
+func _on_focus_changed(control:Control):
+	in_focus = is_open and control.owner == self
 
 func interact(_player_interaction_component):
 	player_interaction_component = _player_interaction_component
@@ -77,6 +82,7 @@ func open(_player_interaction_component):
 	_player_interaction_component.get_parent().menu_pressed.connect(close) #Connecting input action menu to close function.
 	keypad_ui.show()
 	grab_focus_button.grab_focus()
+	in_focus = true
 	is_open = true
 	
 	
@@ -85,6 +91,7 @@ func close(_player_interaction_component):
 	_player_interaction_component.get_parent().menu_pressed.disconnect(close)
 	_player_interaction_component.get_parent().toggled_interface.emit(false)
 	is_open = false
+	in_focus = false
 
 
 func _on_button_received(_passed_string:String):
@@ -159,6 +166,9 @@ func set_state():
 	
 	object_state_updated.emit(interaction_text)
 
+func _unhandled_input(event):
+	if in_focus:
+		get_viewport().set_input_as_handled()
 
 func save():
 	var state_dict = {

--- a/COGITO/Theme/CogitoButton.gd
+++ b/COGITO/Theme/CogitoButton.gd
@@ -86,7 +86,11 @@ func _on_focus_entered() -> void:
 
 func in_context() -> bool:
 	var context = get_viewport().gui_get_focus_owner()
-	return context and shortcut_context and context.get_parent_control() == shortcut_context
+	if context:
+		var context_owner = context.shortcut_context or context.get_parent_control()
+		var our_context = shortcut_context or get_parent_control()
+		return context_owner == our_context
+	return false
 
 func _on_focus_exited() -> void:
 	if get_viewport().gui_get_focus_owner() == null:

--- a/COGITO/Theme/CogitoButton.gd
+++ b/COGITO/Theme/CogitoButton.gd
@@ -8,6 +8,10 @@ var tween_stylebox : StyleBoxFlat
 var styleboxes : Dictionary = {}
 var current_state = BaseButton.DRAW_NORMAL
 
+# Will accept ui_accept keys as long as other shortcuts have been used in context
+@export var accepts_contextual_enter : bool = false
+static var used_shortcut = false
+
 var tween : Tween
 
 func _ready() -> void:
@@ -31,6 +35,25 @@ func _ready() -> void:
 	add_theme_stylebox_override('focus', tween_stylebox)
 	add_theme_stylebox_override('pressed', tween_stylebox)
 
+func press_button_manually():
+	pressed.emit()
+	
+	if tween and tween.is_running(): # Kill the running tween
+		tween.kill()
+	tween = create_tween().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_CUBIC).set_parallel()
+	
+	# That tweens some properties of our tween stylebox to the target stylebox depending on the current state
+	var target = styleboxes[BaseButton.DRAW_PRESSED] as StyleBoxFlat
+	tween.tween_property(tween_stylebox, "bg_color", target.bg_color, tween_time)
+	tween.tween_property(tween_stylebox, "border_color", target.border_color, tween_time)
+	tween.tween_property(tween_stylebox, "border_width_left", target.border_width_left, tween_time)
+	tween.connect('finished',unpress)
+
+func unpress():
+	if not tween or tween.is_running() or not tween.is_valid:
+		# we've likely been overridden since, so don't mess with anything
+		return
+	current_state = BaseButton.DRAW_PRESSED # this will be changed on the next frame
 
 func _process(_delta: float) -> void:
 	if get_draw_mode() != current_state:
@@ -49,6 +72,8 @@ func _process(_delta: float) -> void:
 
 
 func _on_focus_entered() -> void:
+	used_shortcut = false # focus changing implies not using shortcuts
+	
 	if tween and tween.is_running(): # Kill the running tween
 		tween.kill()
 	tween = create_tween().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_CUBIC).set_parallel()
@@ -59,8 +84,15 @@ func _on_focus_entered() -> void:
 	tween.tween_property(tween_stylebox, "border_color", target.border_color, tween_time)
 	tween.tween_property(tween_stylebox, "border_width_left", target.border_width_left, tween_time)
 
+func in_context() -> bool:
+	var context = get_viewport().gui_get_focus_owner()
+	return context and shortcut_context and context.get_parent_control() == shortcut_context
 
 func _on_focus_exited() -> void:
+	if get_viewport().gui_get_focus_owner() == null:
+		# lost focus to a GUI completely
+		used_shortcut = false
+	
 	if tween and tween.is_running(): # Kill the running tween
 		tween.kill()
 	tween = create_tween().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_CUBIC).set_parallel()
@@ -71,6 +103,14 @@ func _on_focus_exited() -> void:
 	tween.tween_property(tween_stylebox, "border_color", target.border_color, tween_time)
 	tween.tween_property(tween_stylebox, "border_width_left", target.border_width_left, tween_time)
 
+func _input(event : InputEvent):
+	if in_context():
+		if shortcut and shortcut.matches_event(event):
+			# let other CogitoButtons know that the current context has had a shortcut used
+			used_shortcut = true
+		elif used_shortcut and accepts_contextual_enter and event.is_action_pressed("ui_accept"):
+			accept_event()
+			press_button_manually()
 
 func _on_pressed():
 	pressed_string.emit(text)


### PR DESCRIPTION
Added shortcuts to the keypad buttons so now when users type numbers on their keyboard or numpad, it will press the corresponding UI button.

Enter serves as 'E' on the keypad
Backspace or Joypad action right button serves as 'C' on the keypad