### PR TITLE
Implement intent-sensitive ladder snapping, sprinting

### DIFF
--- a/COGITO/Scripts/ladder_area.gd
+++ b/COGITO/Scripts/ladder_area.gd
@@ -1,14 +1,19 @@
 extends Area3D
 
 func _ready():
-	body_entered.connect(_on_body_entered)
+	body_shape_entered.connect(_on_body_shape_entered)
 	body_exited.connect(_on_body_exited)
 
 
-func _on_body_entered(body):
+func _on_body_shape_entered(body_rid,body,body_shape_idx,local_shape_idx):
 	if body.is_in_group("Player"):
 		#print("Entered ladder")
-		body.on_ladder = true
+		var local_shape_owner = shape_find_owner(local_shape_idx)
+		var local_shape_node = shape_owner_get_owner(local_shape_owner) as CollisionShape3D
+		
+		var ladderDir = (local_shape_node.global_position - global_position).normalized()
+		
+		body.enter_ladder(local_shape_node,ladderDir)
 
 
 func _on_body_exited(body):

--- a/COGITO/Scripts/player.gd
+++ b/COGITO/Scripts/player.gd
@@ -99,7 +99,9 @@ const WALL_MARGIN : float = 0.001
 
 @export_group("Ladder Handling")
 var on_ladder : bool = false
-@export var ladder_speed : float = 2.0
+@export var CAN_SPRINT_ON_LADDER = false
+@export var LADDER_SPEED : float = 2.0
+@export var LADDER_SPRINT_SPEED : float = 3.3
 const LADDER_JUMP_SCALE = 0.5
 
 @export_group("Gamepad Properties")
@@ -284,6 +286,27 @@ func params(transform3d, motion):
 func test_motion(transform3d: Transform3D, motion: Vector3) -> bool:
 	return PhysicsServer3D.body_test_motion(self_rid, params(transform3d, motion), test_motion_result)	
 
+func enter_ladder(ladder: CollisionShape3D, ladderDir: Vector3):
+	# called by ladder_area.gd
+	
+	# try and capture player's intent based on where they're looking
+	var look_vector = camera.get_camera_transform().basis
+	var looking_away = look_vector.z.dot(ladderDir) < 0.33
+	if not looking_away:
+		# they're going head on with the ladder, likely they want to climb it
+		on_ladder = true
+		return
+	
+	var looking_down = look_vector.z.dot(Vector3.UP) > 0.5
+	
+	# Snapping to "side" of ladder if player seems as though they're aiming to go down the ladder
+	if looking_down and ladderDir:
+		var offset = (global_position - ladder.global_position)
+		if offset.dot(ladderDir) < -0.1:
+			global_translate(ladderDir*offset.length()/4.0)
+		on_ladder = true
+	
+
 ### LADDER MOVEMENT
 func _process_on_ladder(_delta):
 	var input_dir
@@ -291,6 +314,15 @@ func _process_on_ladder(_delta):
 		input_dir = Input.get_vector("left", "right", "forward", "back")
 	else:
 		input_dir = Vector2.ZERO
+	
+	var ladder_speed = LADDER_SPEED
+	
+	if CAN_SPRINT_ON_LADDER and Input.is_action_pressed("sprint") and input_dir.length_squared() > 0.1:
+		is_sprinting = true
+		if stamina_attribute.value_current > 0:
+			ladder_speed = LADDER_SPRINT_SPEED
+	else:
+		is_sprinting = false
 		
 	var jump = Input.is_action_pressed("jump")
 
@@ -308,11 +340,13 @@ func _process_on_ladder(_delta):
 			neck.rotate_y(deg_to_rad(-joystick_v_event.get_axis_value() * JOY_V_SENS))
 			neck.rotation.y = clamp(neck.rotation.y, deg_to_rad(-120), deg_to_rad(120))
 
-	# Applying ladder input_dir to direction
-	direction = (transform.basis * Vector3(input_dir.x,input_dir.y * -1,0)).normalized()
-	velocity = direction * ladder_speed
-
 	var look_vector = camera.get_camera_transform().basis
+	var looking_down = look_vector.z.dot(Vector3.UP) > 0.5
+
+	# Applying ladder input_dir to direction
+	var y_dir = 1 if looking_down else -1
+	direction = (transform.basis * Vector3(input_dir.x,input_dir.y * y_dir,0)).normalized()
+	velocity = direction * ladder_speed
 	
 	if jump:
 		velocity += look_vector * Vector3(JUMP_VELOCITY * LADDER_JUMP_SCALE, JUMP_VELOCITY * LADDER_JUMP_SCALE, JUMP_VELOCITY * LADDER_JUMP_SCALE)

--- a/COGITO/Scripts/player.gd
+++ b/COGITO/Scripts/player.gd
@@ -292,19 +292,13 @@ func enter_ladder(ladder: CollisionShape3D, ladderDir: Vector3):
 	# try and capture player's intent based on where they're looking
 	var look_vector = camera.get_camera_transform().basis
 	var looking_away = look_vector.z.dot(ladderDir) < 0.33
-	if not looking_away:
-		# they're going head on with the ladder, likely they want to climb it
-		on_ladder = true
-		return
-	
 	var looking_down = look_vector.z.dot(Vector3.UP) > 0.5
-	
-	# Snapping to "side" of ladder if player seems as though they're aiming to go down the ladder
-	if looking_down and ladderDir:
+	if looking_down or not looking_away:
 		var offset = (global_position - ladder.global_position)
 		if offset.dot(ladderDir) < -0.1:
 			global_translate(ladderDir*offset.length()/4.0)
 		on_ladder = true
+		return
 	
 
 ### LADDER MOVEMENT


### PR DESCRIPTION
More controller improvements!
Addresses #84

- Implemented sprinting on ladders, with exported vars to enable/disable and set sprinting speed on ladder
- `is_sprinting` will now change correctly so stamina doesn't burn whilst on the ladder for no reason
- Added intent-sensitive ladder movement. Ladder movement will generally prefer "W" being up, but if the player is pointing heavily downwards, then their "W" direction is switched to downwards, and "S" is upwards.
- If the player is looking downwards, and facing opposite the ladder as they enter its collider, it assumes the player is attempting to go down the ladder and snaps them on to it
- Additionally, players should now be able to run perpendicular to a ladder without getting caught on it, as the player now needs to be at least somewhat facing the ladder to go up it.