### PR TITLE
Ladder collision fixes and buffer timer

### DIFF
--- a/COGITO/PrefabScenes/ladder.tscn
+++ b/COGITO/PrefabScenes/ladder.tscn
@@ -45,15 +45,17 @@ shadow_mesh = SubResource("ArrayMesh_s5jyy")
 [sub_resource type="BoxShape3D" id="BoxShape3D_xagqk"]
 size = Vector3(0.8, 3.03359, 0.1)
 
-[node name="Ladder" type="Area3D"]
+[node name="Ladder" type="Area3D" node_paths=PackedStringArray("ladder_collision")]
 transform = Transform3D(-2.98023e-08, 0, -1, 0, 1, 0, 1, 0, -2.98023e-08, -18.4395, 1.6, -4.87125)
 script = ExtResource("1_odht7")
+ladder_collision = NodePath("ladder")
 
 [node name="ladderArea" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.1, 0, 0)
 shape = SubResource("BoxShape3D_rj7xk")
 
 [node name="ladder" type="StaticBody3D" parent="."]
+process_mode = 1
 transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 0, 0, 0)
 
 [node name="generated(Clone)" type="MeshInstance3D" parent="ladder"]
@@ -64,3 +66,4 @@ skeleton = NodePath("")
 [node name="CollisionShape3D" type="CollisionShape3D" parent="ladder"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00152588, -0.0832032, 0)
 shape = SubResource("BoxShape3D_xagqk")
+disabled = true

--- a/COGITO/PrefabScenes/ladder.tscn
+++ b/COGITO/PrefabScenes/ladder.tscn
@@ -55,7 +55,6 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.1, 0, 0)
 shape = SubResource("BoxShape3D_rj7xk")
 
 [node name="ladder" type="StaticBody3D" parent="."]
-process_mode = 1
 transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 0, 0, 0)
 
 [node name="generated(Clone)" type="MeshInstance3D" parent="ladder"]
@@ -66,4 +65,3 @@ skeleton = NodePath("")
 [node name="CollisionShape3D" type="CollisionShape3D" parent="ladder"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00152588, -0.0832032, 0)
 shape = SubResource("BoxShape3D_xagqk")
-disabled = true

--- a/COGITO/Scripts/ladder_area.gd
+++ b/COGITO/Scripts/ladder_area.gd
@@ -1,9 +1,13 @@
 extends Area3D
 
+@export var ladder_collision : CollisionObject3D
+var original_process_mode : ProcessMode
+
 func _ready():
 	body_shape_entered.connect(_on_body_shape_entered)
 	body_exited.connect(_on_body_exited)
-
+	if ladder_collision:
+		original_process_mode = ladder_collision.process_mode
 
 func _on_body_shape_entered(body_rid,body,body_shape_idx,local_shape_idx):
 	if body.is_in_group("Player"):
@@ -14,9 +18,14 @@ func _on_body_shape_entered(body_rid,body,body_shape_idx,local_shape_idx):
 		var ladderDir = (local_shape_node.global_position - global_position).normalized()
 		
 		body.enter_ladder(local_shape_node,ladderDir)
+		if body.on_ladder and ladder_collision:
+			original_process_mode = ladder_collision.process_mode
+			ladder_collision.process_mode = Node.PROCESS_MODE_DISABLED
 
 
 func _on_body_exited(body):
 	if body.is_in_group("Player"):
 		#print("Exited ladder")
 		body.on_ladder = false
+		if ladder_collision:
+			ladder_collision.process_mode = original_process_mode

--- a/COGITO/Scripts/player.gd
+++ b/COGITO/Scripts/player.gd
@@ -100,12 +100,12 @@ const WALL_MARGIN : float = 0.001
 
 @export_group("Ladder Handling")
 var on_ladder : bool = false
-@export var CAN_SPRINT_ON_LADDER = false
+@export var CAN_SPRINT_ON_LADDER : bool = false
 @export var LADDER_SPEED : float = 2.0
 @export var LADDER_SPRINT_SPEED : float = 3.3
 @export var LADDER_COOLDOWN : float = 0.5
-const LADDER_JUMP_SCALE = 0.5
-var ladder_on_cooldown = false
+const LADDER_JUMP_SCALE : float = 0.5
+var ladder_on_cooldown : bool = false
 
 @export_group("Gamepad Properties")
 @export var JOY_DEADZONE : float = 0.25


### PR DESCRIPTION
Whilst doing the last-minute fixes on PR #114, I realized there's a couple of issues with the ladder system that while avoidable with good collision shape placement, it's probably easier to implement these fixes:

- When stepping on the ladder, you have a half second cooldown (configurable) before checking if you're on the ground and you should "step off" the ladder. This makes it so if you're just stepping on to the ladder, you can't accidentally register as "on ground" and immediately come off it. The idea is the player will move within that .5 seconds, and the ground check will have changed.
- In the ladder class, you can configure a "ladder collision" object. If this is set, it will disable the collision object whilst the player is on the ladder, and then set it back to whatever it was when the player comes off it. This prevents the collision object from blocking the player from going up/down the ladder if the player's collider isn't snapped perfectly.

Made this as a separate PR just to make sure these changes get their own chance for review.

You can see the issues with this on `main` by attempting to go down the ladder in the `COGITO_01_Demo` scene, which is fixed in this PR.