### PR TITLE
Add "is_carryable_while_wielding" property

### DIFF
--- a/COGITO/Components/Interactions/CarryableComponent.gd
+++ b/COGITO/Components/Interactions/CarryableComponent.gd
@@ -13,7 +13,7 @@ class_name CarryableComponent
 ## Sets how far away the carried object needs to be from the carry_position before it gets dropped.
 @export var drop_distance : float = 1.5
 ##Sets whether the object can be carried while wielding a weapon
-@export var is_carriable_while_wielding : bool = false
+@export var is_carryable_while_wielding : bool = false
 
 @onready var audio_stream_player_3d = $AudioStreamPlayer3D
 @onready var camera : Camera3D = get_viewport().get_camera_3d()
@@ -39,7 +39,7 @@ func interact(_player_interaction_component:PlayerInteractionComponent):
 
 func carry(_player_interaction_component:PlayerInteractionComponent):
 	player_interaction_component = _player_interaction_component
-	if player_interaction_component.is_wielding and not is_carriable_while_wielding:
+	if player_interaction_component.is_wielding and not is_carryable_while_wielding:
 		player_interaction_component.send_hint(null,"Can't carry an object while wielding.")
 		return
 

--- a/COGITO/Components/Interactions/CarryableComponent.gd
+++ b/COGITO/Components/Interactions/CarryableComponent.gd
@@ -4,6 +4,8 @@ class_name CarryableComponent
 @export_group("Carriable Settings")
 @export var pick_up_sound : AudioStream
 @export var drop_sound : AudioStream
+##Sets whether the object can be carried while wielding a weapon
+@export var is_carryable_while_wielding : bool = false
 ## Use this to adjust the carry position distance from the player. Per default it's the interaction raycast length. Negative values are closer, positive values are further away.
 @export var carry_distance_offset : float = 0
 ## Set if the object should not rotate when being carried. Usually true is preferred.
@@ -12,8 +14,6 @@ class_name CarryableComponent
 @export var carrying_velocity_multiplier : float = 10
 ## Sets how far away the carried object needs to be from the carry_position before it gets dropped.
 @export var drop_distance : float = 1.5
-##Sets whether the object can be carried while wielding a weapon
-@export var is_carryable_while_wielding : bool = false
 
 @onready var audio_stream_player_3d = $AudioStreamPlayer3D
 @onready var camera : Camera3D = get_viewport().get_camera_3d()

--- a/COGITO/Components/Interactions/CarryableComponent.gd
+++ b/COGITO/Components/Interactions/CarryableComponent.gd
@@ -12,6 +12,8 @@ class_name CarryableComponent
 @export var carrying_velocity_multiplier : float = 10
 ## Sets how far away the carried object needs to be from the carry_position before it gets dropped.
 @export var drop_distance : float = 1.5
+##Sets whether the object can be carried while wielding a weapon
+@export var is_carriable_while_wielding : bool = false
 
 @onready var audio_stream_player_3d = $AudioStreamPlayer3D
 @onready var camera : Camera3D = get_viewport().get_camera_3d()
@@ -37,7 +39,7 @@ func interact(_player_interaction_component:PlayerInteractionComponent):
 
 func carry(_player_interaction_component:PlayerInteractionComponent):
 	player_interaction_component = _player_interaction_component
-	if player_interaction_component.is_wielding:
+	if player_interaction_component.is_wielding and not is_carriable_while_wielding:
 		player_interaction_component.send_hint(null,"Can't carry an object while wielding.")
 		return
 


### PR DESCRIPTION
I find it a little tedious having to put away my weapon in order to carry something as small as a battery or a potion. I think it would be better to leave devs with an easy option to disable this for lighter items or across all items entirely.

To that end, I've implemented a really simple bool property in CarryableComponent.gd which lets you toggle this behaviour. Of course, in what I believe to be the spirit of the plugin, I think we can let users worry about the intricacies of their own implementations (in terms of handling potential collision issues between the viewmodel and the carried object if the carry distance is really close for example).

I've tested this and have found no immediate issues but maybe there is a technical reason why this restriction was in place?