### PR TITLE
Instantiate nodes using position instead of global_position

### DIFF
--- a/COGITO/Assets/Shader/ShaderPrecompiler.gd
+++ b/COGITO/Assets/Shader/ShaderPrecompiler.gd
@@ -24,7 +24,7 @@ static func precompile(tree : SceneTree, shader : ShaderMaterial, use_new_node :
 		compiler.position = Vector3(0,0,-0.1) # position self in front of camera
 		
 		compiler.cast_shadow = 0
-		compiler.custom_aabb = AABB(compiler.global_position, Vector3.ONE*100) # make sure we're always rendering
+		compiler.custom_aabb = AABB(compiler.position, Vector3.ONE*100) # make sure we're always rendering
 		
 		tree.root.get_camera_3d().add_child(compiler)
 	else:

--- a/COGITO/Components/Attributes/CogitoHealthAttribute.gd
+++ b/COGITO/Components/Attributes/CogitoHealthAttribute.gd
@@ -41,11 +41,11 @@ func on_death(_attribute_name:String, _value_current:float, _value_max:float):
 	parent_position = get_parent().global_position
 	
 	if sound_on_death:
-		Audio.play_sound_3d(sound_on_death).global_position = parent_position
+		Audio.play_sound_3d(sound_on_death).position = parent_position
 	
 	if spawn_on_death:
 		var spawned_object = spawn_on_death.instantiate()
-		spawned_object.global_position = parent_position
+		spawned_object.position = parent_position
 		get_tree().current_scene.add_child(spawned_object)
 	
 	for nodepath in destroy_on_death:

--- a/COGITO/Scripts/Cogito_Spawnzone.gd
+++ b/COGITO/Scripts/Cogito_Spawnzone.gd
@@ -22,7 +22,7 @@ func spawn_objects():
 		spawn_point.z = randf_range(spawn_area.global_position.z - spawn_area.shape.size.z, spawn_area.global_position.z + spawn_area.shape.size.z )
 		
 		var spawned_object = object_to_spawn.instantiate()
-		spawned_object.global_position = spawn_point
+		spawned_object.position = spawn_point
 		get_tree().current_scene.add_child(spawned_object)
 		
 		left_to_spawn -= 1


### PR DESCRIPTION
This fixes an issue where every time a node is set to spawn upon another's death, or a spawner is used, a non-fatal error message "Condition !is_inside_tree is true" pops up.

Repro steps: shoot a target in any scene and the error will pop up in the console.

I believe this is due to adding the child to the tree before setting its global_position property. Unfortunately, setting the global_position before adding the child to the tree seems to prevent the node from showing (or at least from spawning in the right position).

Using "position" to instantiate the nodes seems to fix this, and I've observed no change in behaviour - however this solution might not follow best practice, so people more familiar with the engine should feel free to come up with something better if needed.