### PR TITLE
Fix laser angle when shooting close to walls

### DIFF
--- a/COGITO/Wieldables/Wieldable_LaserRifle.gd
+++ b/COGITO/Wieldables/Wieldable_LaserRifle.gd
@@ -88,7 +88,7 @@ func hit_scan_collision(collision_point:Vector3):
 	
 	# Spawning a laser ray
 	var instantiated_ray = laser_ray_prefab.instantiate()
-	instantiated_ray.draw_ray(bullet_point.get_global_transform().origin, collision_point + bullet_direction)
+	instantiated_ray.draw_ray(bullet_point.get_global_transform().origin, collision_point)
 	spawn_node.add_child(instantiated_ray)
 	
 	if bullet_collision:


### PR DESCRIPTION
Bullet direction not necessary for drawing the laser between rifle and point of impact - was causing lasers to draw perpendicularly to the player when close to walls.

Old:
![image](https://github.com/Phazorknight/Cogito/assets/59507949/f659aa92-0c64-4734-a0cd-3cc6f3cd0e08)

New:
![image](https://github.com/Phazorknight/Cogito/assets/59507949/27c7b121-2836-463d-8a4c-f4c164a7610e)
