### PR TITLE
Footstep sounds in sync with head wobble, wobble intensity is adjustable

### DIFF
--- a/COGITO/PrefabScenes/player.tscn
+++ b/COGITO/PrefabScenes/player.tscn
@@ -116,9 +116,6 @@ script = ExtResource("16_a6uam")
 generic_fallback_footstep_profile = ExtResource("17_rmtvn")
 footstep_material_library = ExtResource("18_q6u2l")
 
-[node name="FootstepTimer" type="Timer" parent="."]
-one_shot = true
-
 [node name="JumpCooldownTimer" type="Timer" parent="."]
 wait_time = 0.5
 one_shot = true

--- a/COGITO/Scripts/player.gd
+++ b/COGITO/Scripts/player.gd
@@ -125,6 +125,7 @@ var slide_vector : Vector2 = Vector2.ZERO
 var wiggle_vector : Vector2 = Vector2.ZERO
 var wiggle_index : float = 0.0
 var wiggle_current_intensity : float = 0.0
+var can_play_footstep : bool = true
 var bunny_hop_speed : float = SPRINTING_SPEED
 var last_velocity : Vector3= Vector3.ZERO
 var stand_after_roll : bool = false
@@ -144,7 +145,6 @@ var slide_audio_player : AudioStreamPlayer3D
 @onready var crouching_collision_shape: CollisionShape3D = $CrouchingCollisionShape
 @onready var crouch_raycast: RayCast3D = $CrouchRayCast
 @onready var sliding_timer: Timer = $SlidingTimer
-@onready var footstep_timer: Timer = $FootstepTimer
 @onready var jump_timer: Timer = $JumpCooldownTimer
 
 # Adding carryable position for item control.
@@ -793,7 +793,7 @@ func _physics_process(delta):
 			if slide_audio_player:
 				slide_audio_player.stop()
 			
-			if footstep_timer.time_left <= 0:
+			if can_play_footstep && wiggle_vector.y > 0.9:
 				#dynamic volume for footsteps
 				if is_walking:
 					footstep_player.volume_db = walk_volume_db
@@ -802,12 +802,12 @@ func _physics_process(delta):
 				elif is_sprinting:
 					footstep_player.volume_db = sprint_volume_db
 				footstep_surface_detector.play_footstep()
+					
+				can_play_footstep = false
 				
-				#determine interval time between footsteps
-				if velocity.length_squared() >= footstep_interval_change_velocity_square:
-					footstep_timer.start(sprint_footstep_interval)
-				else:
-					footstep_timer.start(walk_footstep_interval)
+			if !can_play_footstep && wiggle_vector.y < 0.9:
+				can_play_footstep = true
+				
 	elif slide_audio_player:
 		slide_audio_player.stop()
 

--- a/COGITO/Scripts/player.gd
+++ b/COGITO/Scripts/player.gd
@@ -54,7 +54,11 @@ var is_showing_ui : bool
 @export var SLIDING_SPEED : float = 5.0
 @export var SLIDE_JUMP_MOD : float = 1.5
 @export var disable_roll_anim : bool = false
+@export var CAN_BUNNYHOP : bool = true
+@export var BUNNY_HOP_ACCELERATION : float = 0.1
+@export var INVERT_Y_AXIS : bool = true
 
+@export_group("Headbob Properties")
 @export_enum("Minimal:0.1", "Average:0.7", "Full:1") var HEADBOBBLE : int
 @export var WIGGLE_ON_WALKING_INTENSITY : float = 0.03
 @export var WIGGLE_ON_WALKING_SPEED : float = 12.0
@@ -62,9 +66,6 @@ var is_showing_ui : bool
 @export var WIGGLE_ON_SPRINTING_SPEED : float = 16.0
 @export var WIGGLE_ON_CROUCHING_INTENSITY : float = 0.08
 @export var WIGGLE_ON_CROUCHING_SPEED : float = 8.0
-@export var CAN_BUNNYHOP : bool = true
-@export var BUNNY_HOP_ACCELERATION : float = 0.1
-@export var INVERT_Y_AXIS : bool = true
 
 @export_group("Stair Handling")
 ## This sets the camera smoothing when going up/down stairs as the player snaps to each stair step.


### PR DESCRIPTION
Started working on a game that uses Cogito as a base, and these seemed like good general enhancements I could bring back in.
1. Footstep sounds no longer use a timer and instead trigger when the head wobble sine value goes over 0.9, ensuring headbob and footsteps are in sync.
2. Headbob intensity values are exposed, and adjusting the headbob settings scale the intensity only. This way footsteps have a consistent interval across settings.
3. Headbob settings are now Full (100%), Average (70%), and Minimal (10%). Though maybe there should be an Off setting (0%)?