### PR TITLE
refactor: Store player attributes in Dictionary instead of Array

### DIFF
--- a/COGITO/SceneManagement/CogitoPlayerState.gd
+++ b/COGITO/SceneManagement/CogitoPlayerState.gd
@@ -19,7 +19,7 @@ var player_state_dir : String = CogitoSceneManager.cogito_state_dir + CogitoScen
 @export var player_sanity : Vector2
 
 #New way of saving player attributes
-@export var player_attributes : Array[Vector2]
+@export var player_attributes : Dictionary
 
 #Saving parameters from the player interaction component
 @export var interaction_component_state : Array
@@ -34,8 +34,8 @@ var player_state_dir : String = CogitoSceneManager.cogito_state_dir + CogitoScen
 @export var player_state_savetime : int
 @export var player_state_slot_name : String
 
-func add_player_attribute_to_state_data(attribute_data:Vector2):
-	player_attributes.append(attribute_data)
+func add_player_attribute_to_state_data(name: String, attribute_data:Vector2):
+	player_attributes[name] = attribute_data
 	
 func clear_saved_attribute_data():
 	player_attributes.clear()

--- a/COGITO/SceneManagement/cogito_scene_manager.gd
+++ b/COGITO/SceneManagement/cogito_scene_manager.gd
@@ -107,8 +107,11 @@ func load_player_state(player, passed_slot:String):
 		
 		# New way of loading player attributes:
 		var loaded_attribute_data = _player_state.player_attributes
-		for i in loaded_attribute_data.size():
-			player.player_attributes[i].set_attribute(loaded_attribute_data[i].x,loaded_attribute_data[i].y)
+		for attribute in loaded_attribute_data:
+			var attribute_data: Vector2 = loaded_attribute_data[attribute]
+			var cur_value = attribute_data.x
+			var max_value = attribute_data.y
+			player.player_attributes[attribute].set_attribute(cur_value, max_value)
 
 		player.global_position = _player_state.player_position
 		player.global_rotation = _player_state.player_rotation
@@ -163,8 +166,10 @@ func save_player_state(player, slot:String):
 	## New way of saving attributes:
 	_player_state.clear_saved_attribute_data()
 	for attribute in player.player_attributes:
-		var attribute_data : Vector2 = Vector2(attribute.value_current,attribute.value_max)
-		_player_state.add_player_attribute_to_state_data(attribute_data)
+		var cur_value = player.player_attributes[attribute].value_current
+		var max_value = player.player_attributes[attribute].value_max
+		var attribute_data := Vector2(cur_value, max_value)
+		_player_state.add_player_attribute_to_state_data(attribute, attribute_data)
 
 	## Adding a screenshot
 	var screenshot_path : String = str(_player_state.player_state_dir + _active_slot + ".png")

--- a/COGITO/Scripts/Player_Hud_Manager.gd
+++ b/COGITO/Scripts/Player_Hud_Manager.gd
@@ -71,7 +71,7 @@ func _setup_player():
 		ui_attribute_area.remove_child(n)
 		n.queue_free()
 		
-	for attribute in player.player_attributes:
+	for attribute in player.player_attributes.values():
 		var spawned_attribute_ui = ui_attribute_prefab.instantiate()
 		ui_attribute_area.add_child(spawned_attribute_ui)
 		if attribute.attribute_name == "health":


### PR DESCRIPTION
Player attributes are accessed by name, thus storing them in a Dictionary makes more sense than in an Array.

These changes edit attribute storing, saving, and loading to use Dictionaries instead. An attempt is also made to make the code ever so slightly more readable by using more descriptive variable names where applicable.

Changes are tested in test maps and seem to function as intended.