### PR TITLE
Simplifies interaction input handling and refactors reload logic to be more performant

### DIFF
--- a/COGITO/Components/PlayerInteractionComponent.gd
+++ b/COGITO/Components/PlayerInteractionComponent.gd
@@ -78,47 +78,29 @@ func interactive_object_exit():
 	object_detected = false
 
 
-func _input(event):
-	if event.is_action_pressed("interact"):
-		
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("interact") or event.is_action_pressed("interact2"):
+		var action: String = "interact" if event.is_action_pressed("interact") else "interact2"
+
 		# if carrying an object, drop it.
-		if is_carrying and is_instance_valid(carried_object) and carried_object.input_map_action == "interact":
+		if is_carrying and is_instance_valid(carried_object) and carried_object.input_map_action == action:
 			carried_object.throw(throw_power)
 		elif is_carrying and !is_instance_valid(carried_object):
 			stop_carrying()
-		
+
 		# Checks if raycast is hitting an interactable object that has an interaction for this input action.
-		if interaction_raycast.is_colliding():
-			interactable = interaction_raycast.get_collider()
-			if interactable.is_in_group("interactable"):
-				for node in interactable.interaction_nodes:
-					if node.input_map_action == "interact":
-						node.interact(self)
+		# This could be run each frame instead and the key be checked when finding an interactable,
+		# which would be slower, but would easily allow any key to be used in the
+		# interaction component and help reduce the nesting.
+		interactable = interaction_raycast.get_collider()
+		if interactable != null and interactable.is_in_group("interactable"):
+			for node: InteractionComponent in interactable.interaction_nodes:
+				if node.input_map_action == action:
+					node.interact(self)
 		interactive_object_exit()
 		if is_wielding:
 			equipped_wieldable_item.update_wieldable_data(self)
-	
-	
-	if event.is_action_pressed("interact2"):
-		# if carrying an object, drop it.
-		if is_carrying and is_instance_valid(carried_object) and carried_object.input_map_action == "interact2":
-			carried_object.throw(throw_power)
-		elif is_carrying and !is_instance_valid(carried_object):
-			stop_carrying()
-		
-		
-		# Checks if raycast is hitting an interactable object that has an interaction for this input action.
-		if interaction_raycast.is_colliding():
-			interactable = interaction_raycast.get_collider()
-			if interactable.is_in_group("interactable"):
-				for node in interactable.interaction_nodes:
-					if node.input_map_action == "interact2":
-						node.interact(self)
-		interactive_object_exit()
-		if is_wielding:
-			equipped_wieldable_item.update_wieldable_data(self)
-	
-	
+
 	# Wieldable primary Action Input
 	if !get_parent().is_movement_paused:
 		if is_wielding and Input.is_action_just_pressed("action_primary"):

--- a/COGITO/Components/PlayerInteractionComponent.gd
+++ b/COGITO/Components/PlayerInteractionComponent.gd
@@ -218,8 +218,7 @@ func attempt_reload():
 	if equipped_wieldable_item.no_reload:
 		return
 
-	# Round up the ammo calculation as the charges are floats, not ints
-	var ammo_needed: int = abs(ceili(equipped_wieldable_item.charge_max - equipped_wieldable_item.charge_current))
+	var ammo_needed: int = abs(equipped_wieldable_item.charge_max - equipped_wieldable_item.charge_current)
 	if ammo_needed <= 0:
 		print("Wieldable is fully charged.")
 		return


### PR DESCRIPTION
- Simplifies PlayerInteractionComponent by merging input checks for interact and interact2 to a single block
- Removes a RayCast3D.is_colliding() check and gets that information via RayCast3D.get_collider() (null if no collision)
- Rewrites the reload logic (removes nesting, removes the while loop, makes the for loop faster by removing the use of InvetoryPD.remove_item_from_stack())

Reload time before:
![reload_before_self](https://github.com/Phazorknight/Cogito/assets/71503746/94404ad9-8e7e-4216-ac2e-2d30729a94b0)

Reload time after:
![reload_after_self](https://github.com/Phazorknight/Cogito/assets/71503746/f10a183a-1bb5-4542-8bf2-126ff55cbced)
