### PR TITLE
when loading a player state, unequip current wieldable before loading

### DIFF
--- a/COGITO/Components/PlayerInteractionComponent.gd
+++ b/COGITO/Components/PlayerInteractionComponent.gd
@@ -183,13 +183,13 @@ func equip_wieldable(wieldable_item:WieldableItemPD):
 
 
 
-func change_wieldable_to(next_wieldable: InventoryItemPD):
+func change_wieldable_to(next_wieldable: InventoryItemPD, force_immediate := false):
 	is_changing_wieldables = true
 	if equipped_wieldable_item != null:
 		equipped_wieldable_item.is_being_wielded = false
 		if equipped_wieldable_node != null:
 			equipped_wieldable_node.unequip()
-			if equipped_wieldable_node.animation_player.is_playing(): #Wait until unequip animation finishes.
+			if not force_immediate and equipped_wieldable_node.animation_player.is_playing(): #Wait until unequip animation finishes.
 				await get_tree().create_timer(equipped_wieldable_node.animation_player.current_animation_length).timeout 
 	equipped_wieldable_item = null
 	if equipped_wieldable_node != null:

--- a/COGITO/SceneManagement/cogito_scene_manager.gd
+++ b/COGITO/SceneManagement/cogito_scene_manager.gd
@@ -116,6 +116,9 @@ func load_player_state(player, passed_slot:String):
 		player.global_position = _player_state.player_position
 		player.global_rotation = _player_state.player_rotation
 		
+		# Force reset wieldable before loading:
+		player.player_interaction_component.change_wieldable_to(null, true)
+		
 		#Loading player interaction component state
 		var player_interaction_component_state = _player_state.interaction_component_state
 		for state_data in player_interaction_component_state:


### PR DESCRIPTION
Fixes #166 

Added an optional argument to change_wieldable_to which allows to skip the await. 
This is required for quick loading the current scene since otherwise the await messes up the loading time resulting in unequipping the wieldable from the loaded data instead of the old one.