### PR TITLE
Fix - Out of ammo hint to use Ammo name

### DIFF
--- a/COGITO/Components/PlayerInteractionComponent.gd
+++ b/COGITO/Components/PlayerInteractionComponent.gd
@@ -163,7 +163,7 @@ func attempt_action_primary(is_released: bool):
 		print("Nothing equipped, but is_wielding was true. This shouldn't happen!")
 		return
 	if equipped_wieldable_item.charge_current == 0:
-		send_hint(null, equipped_wieldable_item.name + " is out of ammo.")
+		send_hint(null, equipped_wieldable_item.name + " is out of " + equipped_wieldable_item.ammo_item_name)
 	else:
 		equipped_wieldable_node.action_primary(equipped_wieldable_item, is_released)
 


### PR DESCRIPTION
Noticed that there was a hint message saying "Flashlight is out of ammo", came up with this as a way to avoid that. This fix makes it now say "Flashlight is out of Battery"

Downside is that it may be too verbose to use full ammo name sometimes, If we want to avoid that could introduce shortened name property to use in places like this. 

Alternatively could attempt to shorten name automatically, maybe something like this:

```
if equipped_wieldable_item.charge_current == 0:
		# If the wieldable is a type of ammo or bullet, shorten to just ammo, to avoid saying things like "Laser Ammo"
		if equipped_wieldable_item.ammo_item_name.to_lower().find("ammo") != -1 or equipped_wieldable_item.ammo_item_name.to_lower().find("bullet") != -1:
			send_hint(null, equipped_wieldable_item.name + " is out of ammo")
		else:
			send_hint(null, equipped_wieldable_item.name + " is out of " + equipped_wieldable_item.ammo_item_name)
```
