### PR TITLE
Fixed issue where Projectile would spawn at world orgin instead of bullet_point in Godot 4.3

### DIFF
--- a/COGITO/Wieldables/toy_pistol.tscn
+++ b/COGITO/Wieldables/toy_pistol.tscn
@@ -77,7 +77,7 @@ bus = &"SFX"
 
 [node name="Bullet_Point" type="Node3D" parent="."]
 unique_name_in_owner = true
-transform = Transform3D(1, 0, -1.81899e-12, 0, 1, 0, 0, 0, 1, 0.277335, 0.0601448, 0.00182778)
+transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 0.277335, 0.0601448, 0.00182778)
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {

--- a/COGITO/Wieldables/wieldable_toy_pistol.gd
+++ b/COGITO/Wieldables/wieldable_toy_pistol.gd
@@ -57,6 +57,8 @@ func action_primary(_passed_item_reference : InventoryItemPD, _is_released: bool
 	# Spawning projectile
 	var Projectile = get_projectile()
 	bullet_point.add_child(Projectile)
+	Projectile.set_global_position(Vector3(bullet_point.global_position.x,bullet_point.global_position.y,bullet_point.global_position.z))
+	Projectile.global_transform.basis = bullet_point.global_transform.basis
 	Projectile.damage_amount = _passed_item_reference.wieldable_damage
 	Projectile.set_linear_velocity(Direction * projectile_velocity)
 	Projectile.reparent(get_tree().get_current_scene())


### PR DESCRIPTION
Hi... first Pull Request ever, figured I would just fix the issue before I brought it up.

I'm on Arch Linux running Godot 4.3, so possibly this is just an issue I'm having but, for some reason the Toy Pistol wieldable would only spawn projectiles at the world origin instead of the bullet_point origin of the player. After adding these two lines of code (Sorry if they are a mess, I'm a novice programmer) it fixed the issue and the Toy Pistol now works as it should. 

Line 46 doesn't really do anything, but while I was troubleshooting, I insured the default value was set correctly. Don't believe that line needs to be added.