### PR TITLE
Quick Fix for issue #283

### DIFF
--- a/COGITO/CogitoObjects/cogito_player.gd
+++ b/COGITO/CogitoObjects/cogito_player.gd
@@ -539,7 +539,7 @@ func _physics_process(delta):
 		try_crouch = Input.is_action_pressed("crouch")
 	
 	
-	if crouched_jump or (not jumped_from_slide and is_on_floor() and try_crouch and !is_movement_paused or crouch_raycast.is_colliding()):
+	if crouched_jump or (not jumped_from_slide and is_on_floor() and try_crouch or crouch_raycast.is_colliding()):
 		# should we be sliding?
 		if is_sprinting and input_dir != Vector2.ZERO and is_on_floor():
 			sliding_timer.start()


### PR DESCRIPTION
Quick Fix for issue #283. Explanation posted there 

> Figured the cause and and a quick fix for this:
> 
> Cause is this line (554) not being able to run head.position.y = lerp(head.position.y, CROUCHING_DEPTH, delta * LERP_SPEED)
> So because movement is being paused, it's causing that line to no longer apply, which is why the player is slowly moving back up.
> It's nothing to do with the standing up code which is why it was hard to track down, its just the crouch code not being run.
> 
> For a quick fix can remove !is_movement_paused from this line (542): if crouched_jump or (not jumped_from_slide and is_on_floor() and try_crouch and !is_movement_paused or crouch_raycast.is_colliding()):
