### PR TITLE
Prevent sound_on_damage_taken playing on Death

### DIFF
--- a/COGITO/Components/Attributes/cogito_health_attribute.gd
+++ b/COGITO/Components/Attributes/cogito_health_attribute.gd
@@ -32,10 +32,10 @@ func _ready() -> void:
 func on_health_change(_health_name:String, _health_current:float, _health_max:float, has_increased:bool):
 	if !has_increased:
 		damage_taken.emit()
-		if sound_on_damage_taken:
+		if sound_on_hit:
 			Audio.play_sound_3d(sound_on_hit).global_position = get_parent().global_position
-			if not _health_current <= 0:
-				Audio.play_sound_3d(sound_on_damage_taken).global_position = get_parent().global_position
+		if sound_on_damage_taken and not _health_current <= 0:
+			Audio.play_sound_3d(sound_on_damage_taken).global_position = get_parent().global_position
 
 
 func on_death(_attribute_name:String, _value_current:float, _value_max:float):

--- a/COGITO/Components/Attributes/cogito_health_attribute.gd
+++ b/COGITO/Components/Attributes/cogito_health_attribute.gd
@@ -8,7 +8,9 @@ signal death()
 
 ## Amount of damage received per second if sanity is zero. Usually only used for Players.
 @export var no_sanity_damage : float
-## Sound that plays when taking damage
+## Sound that plays when taking damage, also played on death. Useful as Bullet impact sound
+@export var sound_on_hit : AudioStream
+## Sound that plays when taking damage, not played on death. Useful as Damage NPC reaction sound 
 @export var sound_on_damage_taken : AudioStream
 ## Sound that plays on death.
 @export var sound_on_death : AudioStream
@@ -31,7 +33,9 @@ func on_health_change(_health_name:String, _health_current:float, _health_max:fl
 	if !has_increased:
 		damage_taken.emit()
 		if sound_on_damage_taken:
-			Audio.play_sound_3d(sound_on_damage_taken).global_position = get_parent().global_position
+			Audio.play_sound_3d(sound_on_hit).global_position = get_parent().global_position
+			if not _health_current <= 0:
+				Audio.play_sound_3d(sound_on_damage_taken).global_position = get_parent().global_position
 
 
 func on_death(_attribute_name:String, _value_current:float, _value_max:float):


### PR DESCRIPTION
Prevent sound_on_damage_taken playing on Death as this overlaps with the death sound currently.

Added a new field of sound_on_hit that will play on every hit including death as I didn't want to remove that functionality as an option. My idea with this is sound_on_hit could be used for something like a bullet hit sound. Whereas sound_on_damage_taken can be used for NPC response to damage