### PR TITLE
Saves try crouch to avoid issues on save game load

### DIFF
--- a/COGITO/CogitoObjects/cogito_player.gd
+++ b/COGITO/CogitoObjects/cogito_player.gd
@@ -811,10 +811,11 @@ func _physics_process(delta):
 	
 	
 	# CROUCH HANDLING dependant on toggle_crouch
-	if TOGGLE_CROUCH and Input.is_action_just_pressed("crouch"):
-		try_crouch = !try_crouch
-	elif !TOGGLE_CROUCH:
-		try_crouch = Input.is_action_pressed("crouch")
+	if !is_movement_paused:
+		if TOGGLE_CROUCH and Input.is_action_just_pressed("crouch"):
+			try_crouch = !try_crouch
+		elif !TOGGLE_CROUCH:
+			try_crouch = Input.is_action_pressed("crouch")
 	
 	
 	if crouched_jump or (not jumped_from_slide and is_on_floor() and try_crouch or crouch_raycast.is_colliding()):
@@ -863,6 +864,7 @@ func _physics_process(delta):
 				is_sprinting = true
 			if is_crouching:
 				is_crouching = false
+				try_crouch = false
 		elif Input.is_action_pressed("sprint") and !stamina_attribute:	
 			if !Input.is_action_pressed("jump") and CAN_BUNNYHOP:
 				bunny_hop_speed = SPRINTING_SPEED
@@ -875,6 +877,7 @@ func _physics_process(delta):
 			is_sprinting = true
 			if is_crouching:
 				is_crouching = false
+				try_crouch = false
 		else:
 			# STANDING UP HANDLING
 			if !is_showing_ui or !is_movement_paused:
@@ -886,6 +889,7 @@ func _physics_process(delta):
 				is_sprinting = false
 				if is_crouching:
 					is_crouching = false
+					try_crouch = false
 
 	if Input.is_action_pressed("free_look") or !sliding_timer.is_stopped() and !is_movement_paused:
 		is_free_looking = true

--- a/COGITO/SceneManagement/cogito_player_state.gd
+++ b/COGITO/SceneManagement/cogito_player_state.gd
@@ -12,6 +12,7 @@ var player_state_dir : String = CogitoSceneManager.cogito_state_dir + CogitoScen
 @export var player_current_scene_path : String
 @export var player_position : Vector3
 @export var player_rotation : Vector3
+@export var player_try_crouch : bool
 
 #Using Vector2 for saving player attributes. X = current, Y = max.
 @export var player_health: Vector2

--- a/COGITO/SceneManagement/cogito_scene_manager.gd
+++ b/COGITO/SceneManagement/cogito_scene_manager.gd
@@ -150,6 +150,10 @@ func load_player_state(player, passed_slot:String):
 
 		player.global_position = _player_state.player_position
 		player.body.global_rotation = _player_state.player_rotation
+		player.try_crouch = _player_state.player_try_crouch
+		# important: ensures the player isn't crouching on game load, regardless
+		# of whether the option "Toggle Crouching" is set to OFF or ON
+		player.is_crouching = player.try_crouch
 		
 		## Loading player sitting state
 		_player_state.load_sitting_state(player) 
@@ -203,6 +207,7 @@ func save_player_state(player, slot:String):
 	_player_state.player_current_scene_path = _current_scene_path
 	_player_state.player_position = player.global_position
 	_player_state.player_rotation = player.body.global_rotation
+	_player_state.player_try_crouch = player.try_crouch
 	
 	## New way of saving attributes:
 	_player_state.clear_saved_attribute_data()


### PR DESCRIPTION
Save the variable 'try_crouch' in CogitoPlayer and ensures crouching doesn't interfere with other movement actions.

- Tested saving and loading from beneath the stairs with "Toggle Crouching" set to both off and on
- Tested behavior with keypad interaction, while attempting to sprint and sit