### PR TITLE
Very minor changes to hide cursor and to make the vehicle more stable

### DIFF
--- a/COGITO/CogitoObjects/cogito_player.gd
+++ b/COGITO/CogitoObjects/cogito_player.gd
@@ -323,7 +323,10 @@ func _on_death():
 func _on_pause_movement():
 	if !is_movement_paused:
 		is_movement_paused = true
-		Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+		# Only show the mouse cursor if it's being used
+		# Also prevents mouse interaction interference while using gamepad
+		if InputHelper.device_index == -1:
+			Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
 
 
 func _on_resume_movement():

--- a/COGITO/DemoScenes/DemoPrefabs/chair_desk.tscn
+++ b/COGITO/DemoScenes/DemoPrefabs/chair_desk.tscn
@@ -114,11 +114,15 @@ size = Vector3(1.40192, 1.05004, 1.21932)
 [node name="chairDesk" type="RigidBody3D" node_paths=PackedStringArray("vehicle_node")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.0202361, -0.543261, -0.168468)
 collision_layer = 3
+axis_lock_angular_x = true
+axis_lock_angular_z = true
 max_contacts_reported = 6
 contact_monitor = true
 script = ExtResource("1_14400")
+rotation_speed = 0.2
 vehicle_node = NodePath(".")
 sit_area_behaviour = 2
+placement_on_leave = 2
 eject_on_fall = true
 horizontal_look_angle = 360.0
 sit_sound = ExtResource("2_tkltg")


### PR DESCRIPTION
- Hides the cursor when `on_pause_movement` is called and not using mouse/keyboard, which prevents the cursor from incorrectly focusing on any centered control nodes rather than any `grab_focus_button`, and also prevents the InfoPanel from centering in the viewport when opening inventories
- Adjusted some of the properties of the Cogito Vehicle, such as locking the x and z angular rotation to make it a bit more stable and reduced its rotation speed to make it more gamepad friendly