### PR TITLE
Expanded upon throw and drop behavior

### DIFF
--- a/addons/cogito/PackedScenes/cogito_player.tscn
+++ b/addons/cogito/PackedScenes/cogito_player.tscn
@@ -131,8 +131,10 @@ landing_material_library = ExtResource("19_pc36t")
 wait_time = 0.5
 one_shot = true
 
-[node name="PlayerInteractionComponent" parent="." node_paths=PackedStringArray("carryable_position", "wieldable_container") instance=ExtResource("20_4f25o")]
+[node name="PlayerInteractionComponent" parent="." node_paths=PackedStringArray("interaction_raycast", "carryable_position", "stamina_attribute", "wieldable_container") instance=ExtResource("20_4f25o")]
+interaction_raycast = NodePath("../Body/Neck/Head/Eyes/Camera/InteractionRaycast")
 carryable_position = NodePath("../Body/Neck/Head/Eyes/Camera/CarryablePosition")
+stamina_attribute = NodePath("../StaminaAttribute")
 wieldable_container = NodePath("../Body/Neck/Head/Wieldables")
 
 [node name="Player_HUD" parent="." node_paths=PackedStringArray("player") instance=ExtResource("21_j3p88")]


### PR DESCRIPTION
I made a few changes to `PlayerInteractionComponent` that allow for finer tuning of throw and drop power, based on the carried object's mass and limited to a max power.
- Using the object's mass in the throw and drop power provides more consistent and less chaotic behavior as very lightweight objects won't be launched at high speeds through the level and very heavy objects will only experience force up to max power.
- Also included the option to drain stamina if throwing objects that exceed a specified throw power threshold.