### PR TITLE
A modified version of the hazard_zone.gd

### DIFF
--- a/addons/cogito/DemoScenes/COGITO_4_Laboratory.tscn
+++ b/addons/cogito/DemoScenes/COGITO_4_Laboratory.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=125 format=4 uid="uid://6hh7o77unixk"]
+[gd_scene load_steps=127 format=4 uid="uid://6hh7o77unixk"]
 
 [ext_resource type="Script" path="res://addons/cogito/SceneManagement/cogito_scene.gd" id="1_4dqq6"]
 [ext_resource type="Texture2D" uid="uid://sdcljx8f5dhj" path="res://addons/cogito/Assets/hdris/kloofendal_48d_partly_cloudy_puresky_2k.hdr" id="1_ponqc"]
@@ -59,6 +59,8 @@
 [ext_resource type="Script" path="res://addons/cogito/Enemies/cogito_patrol_path.gd" id="53_xiupp"]
 [ext_resource type="PackedScene" uid="uid://bdab2cuy8hue6" path="res://addons/cogito/DemoScenes/DemoPrefabs/Swing.tscn" id="57_sjmpt"]
 [ext_resource type="PackedScene" uid="uid://b60auyyy0apwb" path="res://addons/cogito/PackedScenes/Pickups/pickup_health_extension.tscn" id="59_aok6v"]
+[ext_resource type="PackedScene" uid="uid://d2vpt8d74j5u" path="res://addons/cogito/PackedScenes/sanity_drain_attribute_zone.tscn" id="60_lxppk"]
+[ext_resource type="PackedScene" uid="uid://ks0xcampuu3h" path="res://addons/cogito/PackedScenes/stamina_drain_attribute_zone.tscn" id="61_grgat"]
 
 [sub_resource type="PanoramaSkyMaterial" id="PanoramaSkyMaterial_wjbty"]
 panorama = ExtResource("1_ponqc")
@@ -86,7 +88,7 @@ volumetric_fog_ambient_inject = 0.1
 volumetric_fog_sky_affect = 0.1
 volumetric_fog_temporal_reprojection_amount = 0.85
 
-[sub_resource type="Resource" id="Resource_s5xmk"]
+[sub_resource type="Resource" id="Resource_q62nl"]
 resource_local_to_scene = true
 script = ExtResource("4_hlewe")
 grid = true
@@ -899,7 +901,7 @@ environment = SubResource("Environment_obnk3")
 
 [node name="Player" parent="." instance=ExtResource("2_7qwrr")]
 transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 5.13854, 0.8, -5.43073)
-inventory_data = SubResource("Resource_s5xmk")
+inventory_data = SubResource("Resource_q62nl")
 
 [node name="CONNECTOR_TO_LOBBY" type="Node3D" parent="."]
 
@@ -3438,6 +3440,12 @@ transform = Transform3D(-1, 0, 8.74228e-08, 0, 1, 0, -8.74228e-08, 0, -1, 1, 0, 
 
 [node name="HealthExtension" parent="." instance=ExtResource("59_aok6v")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.663539, 1.20757, -11.0947)
+
+[node name="SanityDrainAttributeZone" parent="." instance=ExtResource("60_lxppk")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 7.3874, 0.0438593, 0.461824)
+
+[node name="StaminaDrainAttributeZone" parent="." instance=ExtResource("61_grgat")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 7.54745, 0.0438593, -2.19753)
 
 [connection signal="pressed" from="NavigationRegion3D/SHOOTING_RANGE/KSI_console_spawn/GenericButton" to="NavigationRegion3D/SHOOTING_RANGE/Spawnzone_Targets" method="_on_generic_button_pressed"]
 [connection signal="body_entered" from="NavigationRegion3D/SYSTEMIC_PROPERTIES/Cathode_A" to="NavigationRegion3D/SYSTEMIC_PROPERTIES/Cathode_A" method="_on_body_entered"]

--- a/addons/cogito/PackedScenes/sanity_drain_attribute_zone.tscn
+++ b/addons/cogito/PackedScenes/sanity_drain_attribute_zone.tscn
@@ -1,0 +1,50 @@
+[gd_scene load_steps=7 format=3 uid="uid://d2vpt8d74j5u"]
+
+[ext_resource type="Script" path="res://addons/cogito/Scripts/cogito_attribute_zone.gd" id="1_qemex"]
+[ext_resource type="Texture2D" uid="uid://ltw74nlvopb" path="res://addons/cogito/Assets/Graphics/UiIcons/Ui_Icon_Sanity.png" id="2_cjlfs"]
+[ext_resource type="FontFile" uid="uid://b2jt4ktfqmihq" path="res://addons/cogito/Assets/Fonts/Montserrat/Montserrat-Black.ttf" id="3_832ve"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_in244"]
+size = Vector3(1.5, 0.5, 1.5)
+
+[sub_resource type="BoxMesh" id="BoxMesh_x600l"]
+size = Vector3(1.5, 0.5, 1.5)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_84cqo"]
+transparency = 1
+cull_mode = 2
+albedo_color = Color(0, 0.67, 0, 0.392157)
+rim = 0.0
+rim_tint = 0.0
+backlight = Color(0.509804, 0.294118, 0.294118, 1)
+disable_receive_shadows = true
+
+[node name="SanityDrainAttributeZone" type="Area3D"]
+script = ExtResource("1_qemex")
+player_attribute = "sanity"
+effect_amount = 1.0
+effect_delay = 0.0
+hint_icon = ExtResource("2_cjlfs")
+hint_message = "You're going insane!"
+hint_rate = 4
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
+shape = SubResource("BoxShape3D_in244")
+
+[node name="TransparentBox" type="MeshInstance3D" parent="CollisionShape3D"]
+mesh = SubResource("BoxMesh_x600l")
+skeleton = NodePath("../../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_84cqo")
+
+[node name="Label3D" type="Label3D" parent="CollisionShape3D"]
+transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, 0, 0.5, 0)
+billboard = 1
+double_sided = false
+text = "SANITY DRAIN
+ATTRIBUTE ZONE"
+font = ExtResource("3_832ve")
+font_size = 40
+
+[connection signal="body_entered" from="." to="." method="_on_body_entered"]
+[connection signal="body_exited" from="." to="." method="_on_body_exited"]

--- a/addons/cogito/PackedScenes/stamina_drain_attribute_zone.tscn
+++ b/addons/cogito/PackedScenes/stamina_drain_attribute_zone.tscn
@@ -1,0 +1,48 @@
+[gd_scene load_steps=7 format=3 uid="uid://ks0xcampuu3h"]
+
+[ext_resource type="Script" path="res://addons/cogito/Scripts/cogito_attribute_zone.gd" id="1_720gr"]
+[ext_resource type="Texture2D" uid="uid://dre2xvgfoqv28" path="res://addons/cogito/Assets/Graphics/UiIcons/Ui_Icon_Stamina.png" id="2_8mk41"]
+[ext_resource type="FontFile" uid="uid://b2jt4ktfqmihq" path="res://addons/cogito/Assets/Fonts/Montserrat/Montserrat-Black.ttf" id="3_1y8ld"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_in244"]
+size = Vector3(1.5, 0.5, 1.5)
+
+[sub_resource type="BoxMesh" id="BoxMesh_x600l"]
+size = Vector3(1.5, 0.5, 1.5)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_84cqo"]
+transparency = 1
+cull_mode = 2
+albedo_color = Color(1, 0.833333, 0, 0.392157)
+rim = 0.0
+rim_tint = 0.0
+backlight = Color(0.509804, 0.294118, 0.294118, 1)
+disable_receive_shadows = true
+
+[node name="StaminaDrainAttributeZone" type="Area3D"]
+script = ExtResource("1_720gr")
+player_attribute = "stamina"
+hint_icon = ExtResource("2_8mk41")
+hint_message = "You're losing energy!"
+hint_rate = 3
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
+shape = SubResource("BoxShape3D_in244")
+
+[node name="TransparentBox" type="MeshInstance3D" parent="CollisionShape3D"]
+mesh = SubResource("BoxMesh_x600l")
+skeleton = NodePath("../../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_84cqo")
+
+[node name="Label3D" type="Label3D" parent="CollisionShape3D"]
+transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, 0, 0.5, 0)
+billboard = 1
+double_sided = false
+text = "STAMINA DRAIN
+ATTRIBUTE ZONE"
+font = ExtResource("3_1y8ld")
+font_size = 40
+
+[connection signal="body_entered" from="." to="." method="_on_body_entered"]
+[connection signal="body_exited" from="." to="." method="_on_body_exited"]

--- a/addons/cogito/Scripts/cogito_attribute_zone.gd
+++ b/addons/cogito/Scripts/cogito_attribute_zone.gd
@@ -1,0 +1,88 @@
+extends Area3D
+
+signal apply_attribute_effect()
+
+## Enter the player attribute that is effected within the zone.
+@export var player_attribute: String
+@export var increase_attribute: bool
+## The amount an attribute is changed while in the zone, either immediately or over time based on the effect delay.
+@export_range(0.0, 10.0, 0.01, "or_greater") var effect_amount: float = 5.0
+## The delay time between effect calls. A value of 0 will change the amount over time.
+@export_range(0.0, 10.0, 0.01, "or_greater") var effect_delay: float = 2.0
+## On zone enter sets the effect delay to zero to cause an immediate effect on the attribute.
+@export var skip_delay_on_zone_enter: bool = true
+## Hint icon that appears when player enters the zone.
+@export var hint_icon: Texture2D
+## Hint text that appears when player enteres the zone. Leave blank if you don't want a hint to appear.
+@export var hint_message: String
+## Adds a hint message at this rate of effect. Only works when using a delay.
+## For example, a rate of 5 will show the hint after every 5 times the attribute is changed by the zone.
+## A rate of 0 won't show the hint again after entering the zone.
+@export_range(0, 10, 1, "or_greater") var hint_rate: int = 5
+## Used to activate / deactivate this zone on runtime.
+@export var is_active: bool = true
+
+var is_within_zone: bool
+var player
+var delay_time: float
+var hint_count: int
+var hint_delay_time: float
+
+
+func _on_body_entered(body):
+	if body.is_in_group("Player"):
+		if !player:
+			player = body
+		if effect_amount > 0 and hint_message != "":
+			body.player_interaction_component.send_hint(hint_icon, hint_message)
+		is_within_zone = true
+		delay_time = 0 if skip_delay_on_zone_enter else effect_delay
+		hint_delay_time = hint_rate
+		hint_count = 0
+
+
+func _on_body_exited(body):
+	if body.is_in_group("Player"):
+		is_within_zone = false
+
+
+func interact(_player_interaction_component: PlayerInteractionComponent):
+	if is_active:
+		monitoring = false
+		is_active = false
+	else:
+		monitoring = true
+		is_active = true
+
+
+func _process(delta):
+	if effect_amount == 0.0 or !is_active:
+		return
+	
+	if is_within_zone:
+		# Run the timer out before changing the attribute value
+		delay_time -= delta
+		if delay_time > 0:
+			return
+		delay_time = effect_delay
+		
+		# Instantly change the attribute by the effect amount if running a delay
+		# Otherwise, change the effect amount over time using the frame delta
+		var amount = effect_amount if effect_delay > 0 else effect_amount * delta
+		
+		if increase_attribute:
+			player.increase_attribute(player_attribute, amount, ConsumableItemPD.ValueType.CURRENT)
+		else:
+			player.decrease_attribute(player_attribute, amount)
+		
+		if hint_message != "" and hint_rate > 0:
+			if effect_delay > 0:
+				hint_count += 1
+				if hint_count >= hint_rate:
+					hint_count = 0
+					player.player_interaction_component.send_hint(hint_icon, hint_message)
+			else:
+				hint_delay_time -= delta
+				if hint_delay_time <= 0:
+					hint_delay_time = hint_rate
+					player.player_interaction_component.send_hint(hint_icon, hint_message)


### PR DESCRIPTION
- Adds the ability to change an attribute after a delay or run it over time as it currently does in hazard_zone.gd
- Adds the ability to change how frequently the hint message is displayed, with a rate of 0 only displaying it once upon entering the zone as it currently does in hazard_zone.gd

You can find a couple of test zones in the laboratory across from the original heal and hazard zones.