### PR TITLE
cogito_button: Added class_name CogitoButton to allow scripts to inherit it

### DIFF
--- a/addons/cogito/CogitoObjects/cogito_button.gd
+++ b/addons/cogito/CogitoObjects/cogito_button.gd
@@ -1,5 +1,6 @@
 @icon("res://addons/cogito/Assets/Graphics/Editor/Icon_CogitoButton.svg")
 extends Node3D
+class_name CogitoButton
 signal object_state_updated(interaction_text: String) #used to display correct interaction prompts
 signal pressed()
 signal damage_received(damage_value:float)

--- a/addons/cogito/CogitoObjects/cogito_button.gd
+++ b/addons/cogito/CogitoObjects/cogito_button.gd
@@ -2,7 +2,7 @@
 extends Node3D
 class_name CogitoButton
 signal object_state_updated(interaction_text: String) #used to display correct interaction prompts
-signal pressed()
+signal pressed(button: CogitoButton)
 signal damage_received(damage_value:float)
 
 
@@ -94,7 +94,7 @@ func press():
 			player_interaction_component.send_hint(null, currency_check.not_enough_currency_hint)
 			return
 	
-	pressed.emit()
+	pressed.emit(self)
 	Audio.play_sound_3d(press_sound).global_position = global_position
 	
 	if !allows_repeated_interaction:

--- a/addons/cogito/CogitoObjects/cogito_button.gd
+++ b/addons/cogito/CogitoObjects/cogito_button.gd
@@ -2,7 +2,8 @@
 extends Node3D
 class_name CogitoButton
 signal object_state_updated(interaction_text: String) #used to display correct interaction prompts
-signal pressed(button: CogitoButton)
+signal pressed()
+signal pressed_ref(button: CogitoButton) #same as pressed but passes pressed button instance
 signal damage_received(damage_value:float)
 
 
@@ -93,8 +94,9 @@ func press():
 		if not currency_check.check_for_currency(player_interaction_component.get_parent()):
 			player_interaction_component.send_hint(null, currency_check.not_enough_currency_hint)
 			return
-	
-	pressed.emit(self)
+
+	pressed.emit()
+	pressed_ref.emit(self)
 	Audio.play_sound_3d(press_sound).global_position = global_position
 	
 	if !allows_repeated_interaction:


### PR DESCRIPTION
I have a project that creates a button that inherits from cogito_button, but to do this, cogito_button needs to have a set `class_name` property.

I also changed the `pressed()` signal to pass a reference to itself. This is handy in cases where you have an object (say: a vending machine) and you get references to all the buttons in a for loop and connect them to a central `_on_button_pressed` function. Then when a button is pressed, you can determine which button was pressed.