### PR TITLE
Bug fix for current build: Update cogito_player.gd

### DIFF
--- a/addons/cogito/CogitoObjects/cogito_player.gd
+++ b/addons/cogito/CogitoObjects/cogito_player.gd
@@ -1026,9 +1026,11 @@ func _physics_process(delta):
 				main_velocity += platform_velocity
 			
 			if is_sprinting and CAN_BUNNYHOP:
-				bunny_hop_speed += BUNNY_HOP_ACCELERATION
-			elif is_sprinting and !CAN_BUNNYHOP:
-				SPRINTING_SPEED += SPRINTING_SPEED
+				bunny_hop_speed += BUNNY_HOP_ACCELERATION # if CAN_BUNNYHOP, bunny_hop_speed should currently be equal to SPRINTING_SPEED. On landing, bunny_hop_speed gets reset.
+
+
+			#elif is_sprinting and !CAN_BUNNYHOP: # BUG: Since SPRINTING_SPEED is not altered if we can't bunnyhop, no need to adjust it back
+				#SPRINTING_SPEED += SPRINTING_SPEED # NOTE: If we want to set a JumpAccel, we can do so in a similar way as the bunny_hop_speed is being handled
 			
 			if is_crouching:
 				#temporarily switch colliders to process jump correctly


### PR DESCRIPTION
Commented out the cause of the bug from issue #362
Small two-line adjustment

Since we aren't adjusting the `SPRINTING_SPEED` at any point, there's no need to add it back to itself.

If adding a Jump Acceleration is the desired behavior, I detailed how we could achieve that in the comments using a similar method as `bunny_hop_speed`