### PR TITLE
Implemented new spawning logic for just item spawning for the loot component

### DIFF
--- a/addons/cogito/CogitoObjects/cogito_loot_drop_container.gd
+++ b/addons/cogito/CogitoObjects/cogito_loot_drop_container.gd
@@ -2,7 +2,7 @@ class_name LootDropContainer extends CogitoContainer
 
 
 ## Enables the debug prints. There are quite a few so output may be crowded.
-@onready var debug_prints: bool = CogitoGlobals.cogito_settings.loot_generator_debug
+@onready var debug_prints: bool = CogitoGlobals.cogito_settings.loot_drop_container_debug
 
 ## Determine the despawning logic for this container.
 @export var despawning_logic := DespawningLogic.NONE:

--- a/addons/cogito/CogitoObjects/cogito_lootable_container.gd
+++ b/addons/cogito/CogitoObjects/cogito_lootable_container.gd
@@ -1,7 +1,7 @@
 class_name LootableContainer extends CogitoContainer
 
 ## Enables the debug prints. There are quite a few so output may be crowded.
-@onready var debug_prints: bool = CogitoGlobals.cogito_settings.loot_generator_debug
+@onready var debug_prints: bool = CogitoGlobals.cogito_settings.lootable_container_debug
 
 ## Determine the despawning logic for this container.
 @export_category("Execution Configuration")

--- a/addons/cogito/CogitoObjects/cogito_object.gd
+++ b/addons/cogito/CogitoObjects/cogito_object.gd
@@ -12,7 +12,7 @@ signal object_exits_tree()
 var interaction_nodes : Array[Node]
 var cogito_properties : CogitoProperties = null
 var properties : int
-
+var spawned_loot_item: bool = false
 
 func _ready():
 	self.add_to_group("interactable")
@@ -25,6 +25,10 @@ func _ready():
 func set_state():	
 	#TODO: Find a way to possibly save health of health attribute.
 	find_cogito_properties()
+	
+	if spawned_loot_item:
+		add_to_group("spawned_loot_items")
+		
 	pass
 
 
@@ -40,6 +44,9 @@ func find_cogito_properties():
 
 # Function to handle persistence and saving
 func save():
+	if self.is_in_group("spawned_loot_items"):
+		spawned_loot_item = true
+		
 	var node_data = {
 		"filename" : get_scene_file_path(),
 		"parent" : get_parent().get_path(),
@@ -52,7 +59,7 @@ func save():
 		"rot_x" : rotation.x,
 		"rot_y" : rotation.y,
 		"rot_z" : rotation.z,
-		
+		"spawned_loot_item" : spawned_loot_item,
 	}
 
 	# If the node is a RigidBody3D, then save the physics properties of it

--- a/addons/cogito/Components/LootComponent.gd
+++ b/addons/cogito/Components/LootComponent.gd
@@ -3,11 +3,16 @@ class_name LootComponent extends Node3D
 
 
 ## Enables the debug prints. There are quite a few so output may be crowded.
-@onready var debug_prints: bool = CogitoGlobals.cogito_settings.loot_generator_debug
+@onready var debug_prints: bool = CogitoGlobals.cogito_settings.loot_component_debug
 
 @export_category("Master Control")
 ## Enables or disables the loot components functionality.
 @export var enabled = true
+## Determine the spawning logic for this container.
+@export var spawning_logic := SpawningLogic.NONE:
+	set(value):
+		spawning_logic = value
+		notify_property_list_changed()
 
 @export_category("Loot Table Configuration")
 ## Specifies which loot table should be used to spawn items from.
@@ -28,6 +33,12 @@ var _player: CogitoPlayer
 var _player_hud: CogitoPlayerHudManager
 var _player_inventory: CogitoInventory
 
+enum SpawningLogic {
+NONE = 0, ## Default spawning logic, will not actually spawn anything even if component is enabled.
+SPAWN_ITEM = 1, ## Spawns an item defined in the InventoryItemPD's drop_scene variable instead of a container. 
+SPAWN_CONTAINER = 2, ## Spawns a loot drop container to fill up with rolled items. 
+}
+
 func _get_configuration_warnings():
 	if !loot_table:
 		return ["Loot table is not set. It is required for the loot component to function."]
@@ -42,8 +53,37 @@ func _set_up_references():
 	_player = get_tree().get_first_node_in_group("Player")
 	_player_hud = _player.find_child("Player_HUD", true, true)
 	_player_inventory = _player.inventory_data
-	health_component_to_monitor.death.connect(_spawn_loot_container)
+	
+	if spawning_logic == SpawningLogic.SPAWN_ITEM:
+		health_component_to_monitor.death.connect(_spawn_loot)
+	elif spawning_logic == SpawningLogic.SPAWN_CONTAINER:
+		health_component_to_monitor.death.connect(_spawn_loot_container)
+	else:
+		CogitoGlobals.debug_log(debug_prints, "Loot Component", "Spawning Logic for this loot component is set to None. Component will not function. Parent: " + str(get_parent()))
 
+
+## Spawns the loot rolled by the loot generator. 
+func _spawn_loot():
+	## Parent node's global position
+	var parent_position = get_parent().global_position
+	## The array of rolled items from which we will get the drop_scene variables from.
+	var items_to_spawn: Array[Dictionary]
+	
+	if enabled and amount_of_items_to_drop > 0:
+		var lootgen = LootGenerator.new()
+		get_tree().current_scene.add_child(lootgen)
+		items_to_spawn = lootgen.generate(loot_table, amount_of_items_to_drop)
+		lootgen.call_deferred("queue_free")
+		
+		for item in items_to_spawn:
+			if item.inventory_item.drop_scene != null:
+				var item_to_spawn = load(item.inventory_item.drop_scene)
+				var spawned_item = item_to_spawn.instantiate()
+				spawned_item.position = parent_position
+				get_tree().current_scene.call_deferred("add_child", spawned_item)
+				var impulse = Vector3(randf_range(0,3),5,randf_range(0,3))
+				spawned_item.call_deferred("apply_central_impulse", impulse)
+			
 
 ## Spawns the loot container defined in the loot_bag_scene variable.
 func _spawn_loot_container():

--- a/addons/cogito/InventoryPD/cogito_loot_generator.gd
+++ b/addons/cogito/InventoryPD/cogito_loot_generator.gd
@@ -120,7 +120,7 @@ func _count_quest_items(item: InventoryItemPD) -> int:
 	var _loot_bags: Array[Node] = get_tree().get_nodes_in_group("loot_bag")
 	_loot_bags.append_array(get_tree().get_nodes_in_group("lootable_containers"))
 	var _spawned_items: Array[Node] = get_tree().get_nodes_in_group("spawned_loot_items")
-	print(_spawned_items)
+
 	var _loot_bags_slots: Array[InventoryItemPD]
 	var _spawned_items_in_scene: Array[InventoryItemPD] = []
 	var _player_inventory_slots: Array[InventoryItemPD] = _player_inventory.get_all_items()

--- a/addons/cogito/InventoryPD/cogito_loot_generator.gd
+++ b/addons/cogito/InventoryPD/cogito_loot_generator.gd
@@ -85,18 +85,29 @@ func _sort_loot_table(loot_table: LootTable):
 ## Checks for given InventoryPD item against player inventory, loot bags, and lootable containers, returns true if there is a copy of a unique item, false if there isn't.
 func _is_unique_found(item: InventoryItemPD):
 	var _loot_bags: Array[Node] = get_tree().get_nodes_in_group("loot_bag")
+	var _spawned_items: Array[Node] = get_tree().get_nodes_in_group("spawned_loot_items")
 	_loot_bags.append_array(get_tree().get_nodes_in_group("lootable_containers"))
 	
-	var _loot_bags_slots: Array[InventoryItemPD]
+	var _loot_bags_slots: Array[InventoryItemPD] = []
+	var _spawned_items_in_scene: Array[InventoryItemPD] = []
 	var _player_inventory_slots: Array[InventoryItemPD] = _player_inventory.get_all_items()
-	var _lookup_merge: Array[InventoryItemPD]
+	var _lookup_merge: Array[InventoryItemPD] = []
 	
 	if _loot_bags.size() > 0:
 		for i in _loot_bags:
 			_loot_bags_slots.append_array(i.inventory_data.get_all_items())
 	
+	if _spawned_items.size() > 0:
+		for i in _spawned_items:
+			var children = []
+			children = i.get_children()
+			for child in children:
+				if child is PickupComponent:
+					_spawned_items_in_scene.append(child.slot_data.inventory_item)
+	
 	_lookup_merge.append_array(_player_inventory_slots)
 	_lookup_merge.append_array(_loot_bags_slots)
+	_lookup_merge.append_array(_spawned_items_in_scene)
 	
 	for _slot in _lookup_merge:
 		if _slot.is_unique:
@@ -108,16 +119,28 @@ func _is_unique_found(item: InventoryItemPD):
 func _count_quest_items(item: InventoryItemPD) -> int:
 	var _loot_bags: Array[Node] = get_tree().get_nodes_in_group("loot_bag")
 	_loot_bags.append_array(get_tree().get_nodes_in_group("lootable_containers"))
+	var _spawned_items: Array[Node] = get_tree().get_nodes_in_group("spawned_loot_items")
+	print(_spawned_items)
 	var _loot_bags_slots: Array[InventoryItemPD]
+	var _spawned_items_in_scene: Array[InventoryItemPD] = []
 	var _player_inventory_slots: Array[InventoryItemPD] = _player_inventory.get_all_items()
 	var _lookup_merge: Array[InventoryItemPD]
 	
 	if _loot_bags.size() > 0:
 		for i in _loot_bags:
 			_loot_bags_slots.append_array(i.inventory_data.get_all_items())
+			
+	if _spawned_items.size() > 0:
+		for i in _spawned_items:
+			var children = []
+			children = i.get_children()
+			for child in children:
+				if child is PickupComponent:
+					_spawned_items_in_scene.append(child.slot_data.inventory_item)
 	
 	_lookup_merge.append_array(_player_inventory_slots)
 	_lookup_merge.append_array(_loot_bags_slots)
+	_lookup_merge.append_array(_spawned_items_in_scene)
 	
 	var _count: int
 	for _slot in _lookup_merge:

--- a/addons/cogito/PackedScenes/target_destructable.tscn
+++ b/addons/cogito/PackedScenes/target_destructable.tscn
@@ -85,6 +85,7 @@ material_properties = 1
 
 [node name="LootComponent" type="Node3D" parent="." node_paths=PackedStringArray("health_component_to_monitor")]
 script = ExtResource("7_s82pn")
+spawning_logic = 1
 loot_table = ExtResource("8_ywkh5")
 amount_of_items_to_drop = 5
 loot_bag_scene = ExtResource("9_dtbx4")


### PR DESCRIPTION
- Added spawning logic to either spawn a container or the item defined in drop_scene from InventoryItemPD.

- Added a small impulse to spawned items so they don't bunch up.

- Fixed debug variables pointing to wrong option, now they correctly toggle with their intended variables.

This way of spawning items is much more interactive and entertaining. I had to stop myself from filling the entire room with potions. However these items are not picked up by autopickup component. Player has to manually clean all this up.

![image](https://github.com/user-attachments/assets/2aca6464-8343-4712-b23a-02f36e3d5c31)
