### PR TITLE
Fix the possibility of adding non-CogitoObjects to pickup_item_pool

### DIFF
--- a/addons/cogito/Components/AutoPickUpZone.gd
+++ b/addons/cogito/Components/AutoPickUpZone.gd
@@ -25,9 +25,10 @@ func _ready() -> void:
 
 
 func _on_body_entered(body: Node3D) -> void:
-	pickup_item_pool.append(body)
-	is_processing_queue = true
-	#_attempt_pick_up(body)
+	if body is CogitoObject:
+		pickup_item_pool.append(body)
+		is_processing_queue = true
+		#_attempt_pick_up(body)
 
 
 func _physics_process(_delta) -> void:


### PR DESCRIPTION
Fixes this error:
![Screenshot from 2025-06-05 10-48-14](https://github.com/user-attachments/assets/ee6364b1-58ab-40f3-96da-4dbcfa4835cf)
