### PR TITLE
Allows PickupComponent and BackpackComponent interaction while carrying an object

### DIFF
--- a/addons/cogito/Components/PlayerInteractionComponent.gd
+++ b/addons/cogito/Components/PlayerInteractionComponent.gd
@@ -108,13 +108,23 @@ func _input(event: InputEvent) -> void:
 func _handle_interaction(action: String) -> void:
 	# if carrying an object, drop it.
 	if is_carrying:
-		if is_instance_valid(carried_object) and carried_object.input_map_action == action:
-			_drop_carried_object()
-			#carried_object.throw(1)
-			return
-		elif !is_instance_valid(carried_object):
+		if is_instance_valid(carried_object):
+			if carried_object.input_map_action == action:
+				_drop_carried_object()
+				#carried_object.throw(1)
+				return
+			else:
+				# Allow 'take' input actions for the carried object
+				var carry_parent: CogitoObject = carried_object.get_parent() as CogitoObject
+				if carry_parent:
+					for node: InteractionComponent in carry_parent.interaction_nodes:
+						if node is PickupComponent or node is BackpackComponent:
+							if node.input_map_action == action:
+								node.interact(self)
+								return
+		else:
 			stop_carrying()
-			return	
+			return
 
 	# Check if we have an interactable in view and are pressing the correct button
 	if interactable != null and not is_carrying:

--- a/addons/cogito/PackedScenes/inventory_bag.tscn
+++ b/addons/cogito/PackedScenes/inventory_bag.tscn
@@ -14,13 +14,13 @@ collision_layer = 3
 script = ExtResource("1_avnnw")
 display_name = "Bag of Holding"
 
-[node name="CarryableComponent" parent="." instance=ExtResource("2_da5wv")]
-
-[node name="BackpackComponent" parent="." instance=ExtResource("3_fg43q")]
-
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00131226, -0.200554, -0.000480652)
 shape = SubResource("BoxShape3D_rd5pj")
 
 [node name="bag2" parent="." instance=ExtResource("4_skhg5")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.5, 0)
+
+[node name="BackpackComponent" parent="." instance=ExtResource("3_fg43q")]
+
+[node name="CarryableComponent" parent="." instance=ExtResource("2_da5wv")]

--- a/addons/cogito/Scripts/player_hud_manager.gd
+++ b/addons/cogito/Scripts/player_hud_manager.gd
@@ -232,6 +232,19 @@ func delete_interaction_prompts() -> void:
 
 func set_drop_prompt(_carrying_node):
 	delete_interaction_prompts()
+	
+	# Create an input prompt if a PickupComponent or BackpackComponent exists
+	# This approach isn't great, but doesn't affect the passed argument or connected signals
+	# Build this input prompt first to maintain the same prompt layout
+	var carry_parent: CogitoObject = _carrying_node.get_parent() as CogitoObject
+	if carry_parent:
+		for node: InteractionComponent in carry_parent.interaction_nodes:
+			if node is PickupComponent or node is BackpackComponent:
+				var instanced_take_prompt: UiPromptComponent = prompt_component.instantiate()
+				prompt_area.add_child(instanced_take_prompt)
+				instanced_take_prompt.set_prompt(node.interaction_text, node.input_map_action)
+				break # Break out of the loop as no object should have both
+	
 	var instanced_prompt: UiPromptComponent = prompt_component.instantiate()
 	prompt_area.add_child(instanced_prompt)
 	instanced_prompt.set_prompt("Drop", _carrying_node.input_map_action)


### PR DESCRIPTION
- Checks the carried object for a PickupComponent or BackpackComponent, and if present, shows the input prompt and allows interaction with these components.
- A quality-of-life enhancement that retains the player's ability to pick up the carried object.
- Rearranged the inventory_bag scene children such that the BackpackComponent is childed above the CarryableComponent, because the input prompts are shown in the order they're childed (while not carrying an object).
- This feature makes the most sense when it comes to items that can be both placed in inventory and used in Snap Slots where you're expected to carry objects into snap shapes but may decide to put them back into inventory instead.
- Without this feature you must drop the object (somewhere safe) and then look down at it to pick it up, or worse, drop it and then quickly pick it up while it's falling. This is a bit inconvenient and not very immersive.
- This implementation could certainly be reworked, I just wanted to change as little as possible.

https://github.com/user-attachments/assets/bbec6163-0c8d-44c7-8a3a-0560e4a0af48