### PR TITLE
Allows context-sensitive cycling through all quickslotted wieldables

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -216,6 +216,18 @@ ui_prev_tab={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":9,"pressure":0.0,"pressed":true,"script":null)
 ]
 }
+quickslot_prev_wieldable={
+"deadzone": 0.2,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":4,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
+quickslot_next_wieldable={
+"deadzone": 0.2,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":5,"canceled":false,"pressed":false,"double_click":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":3,"pressure":0.0,"pressed":true,"script":null)
+]
+}
 
 [internationalization]
 


### PR DESCRIPTION
- Pressing "interact2" (E on keyboard, top face button on gamepad) will cycle through quickslotted wieldables
- Don't worry, it's context-sensitive and only works when not detecting an interactable that uses the "interact2" input action
- Serves as a convenience feature found in most modern FPS-style games, allowing for quick cycling between wieldables using a single input button
- The E key is more convenient to press, can be pressed more intuitively, and for gamepads this gives the player the ability to select a quickslotted wieldable using either hand on the controller (d-pad with the left and top face button with the right)
- Very simple implementation in a single class and works with existing Cogito functionality to hopefully be bug-free