### PR TITLE
Added option for floor slope to affect run exhaustion speed and enhanced UI stamina attribute display behavior

### DIFF
--- a/addons/cogito/Components/Attributes/cogito_stamina_attribute.gd
+++ b/addons/cogito/Components/Attributes/cogito_stamina_attribute.gd
@@ -6,12 +6,22 @@ class_name CogitoStaminaAttribute
 @export var jump_exhaustion : float = 1
 @export var regenerate_after : float = 2
 @export var auto_regenerate : bool = true
+@export_group("Floor Slope Exhaustion Settings")
+## If unused, running only drains stamina at the base run exhaustion speed
+@export var use_floor_slope_for_run_exhaustion: bool = true
+## The max exhaustion speed whil running uphill
+@export var uphill_run_exhaustion_max_speed: float = 6.0
+## The max exhaustion speed whil running downhill
+@export var downhill_run_exhaustion_max_speed: float = 2.0
+## Adjusts the exhaustion speed when detecting vertical motion on steps
+@export var step_slope_multiplier: float = 4.0
 
 var regen_timer : Timer
 var stamina_regen_wait : float
 var is_regenerating : bool
 var player : Node3D
-
+# Use for run exhaustion on slopes, to get vertical travel difference per frame
+var last_y : float
 
 func _ready() -> void:
 	value_current = value_start
@@ -33,12 +43,46 @@ func _process(delta):
 	if player.is_sprinting and player.current_speed > player.WALKING_SPEED and player.velocity.length() > 0.1:
 		regen_timer.stop()
 		is_regenerating = false
-		subtract(run_exhaustion_speed * delta)
-		
+		var exhaustion: float = _run_exhaustion()
+		subtract(exhaustion * delta)
+	last_y = player.global_position.y
+	
 	if !is_regenerating and regen_timer.is_stopped() and value_current < value_max and !player.is_sprinting:
 		regen_timer.start()
 
 
 func _on_regen_timer_timeout():
-	if !is_regenerating:
-		is_regenerating = true
+	#if !is_regenerating: # This led to the regen timer to be called every 'regenerate_after'
+		#is_regenerating = true
+	is_regenerating = value_current < value_max
+
+
+## Adjusts run exhaustion speed based on floor slope and vertical motion
+func  _run_exhaustion() -> float:
+	if !use_floor_slope_for_run_exhaustion:
+		return run_exhaustion_speed
+	
+	# Using floor slope to determine run exhaustion speed
+	var floor_normal: Vector3 = player.get_floor_normal()
+	var movement_direction: Vector3 = player.main_velocity.normalized()
+	# Between -1 (180 deg) and 1 (0 deg), based on move direction
+	var slope_factor: float = movement_direction.dot(floor_normal)
+	
+	if is_equal_approx(slope_factor, 0.0): # Running on a flat surface
+		# Catches sprinting on flat stairs using last player y position and a multiplier
+		if !is_equal_approx(player.global_position.y, last_y): # Still moved up or down
+			#print("running on a stepped surface")
+			slope_factor = (last_y - player.global_position.y) * step_slope_multiplier
+			slope_factor = clampf(slope_factor, -1.0, 1.0)
+		else: # Running on flat ground and not moving up or down
+			#print("flat ground exhaustion speed is ", run_exhaustion_speed)
+			return run_exhaustion_speed
+	
+	if slope_factor < 0.0001: # Running uphill
+		var uphill_run_exhaustion: float = lerpf(run_exhaustion_speed, uphill_run_exhaustion_max_speed, abs(slope_factor))
+		#print("uphill exhaustion speed is ", uphill_run_exhaustion)
+		return uphill_run_exhaustion
+	else: # Running downhill
+		var downhill_run_exhaustion: float = lerpf(run_exhaustion_speed, downhill_run_exhaustion_max_speed, slope_factor)
+		#print("downhill exhaustion speed is ", downhill_run_exhaustion)
+		return downhill_run_exhaustion

--- a/addons/cogito/Components/UI/Ui_StaminaAttribute.gd
+++ b/addons/cogito/Components/UI/Ui_StaminaAttribute.gd
@@ -1,8 +1,18 @@
 extends CogitoAttributeUi
 
-@onready var display_timer : Timer
 
+## When the attribute reaches its max value fade it out quickly.
+@export var start_fade_at_value_max: bool = true
+## Will fade out, even while value increases. If false will only fade out when at max.
+@export var fade_on_attribute_increase: bool = true
+## If the attribute is fully transparent when increasing to its max value, display it once
+@export var blink_fade_at_value_max: bool = true
 @export var time_before_fadeout: float = 1.5
+@onready var display_timer : Timer
+# Cache the tween so we can abort the fade when the attribute changes
+@onready var display_tween: Tween
+
+var last_value: float
 
 func _ready() -> void:
 	display_timer = Timer.new()
@@ -15,15 +25,38 @@ func _ready() -> void:
 	modulate = Color.TRANSPARENT
 
 func on_attribute_changed(_attribute_name:String,_value_current:float,_value_max:float,_has_increased:bool):
-	if !_has_increased:
-		modulate = Color.WHITE
 	
+	if !_has_increased:
+		_stop_fade_and_show(Color.WHITE)
+	else: # Attribute increased
+		if _value_current == _value_max and last_value < _value_max:
+			# The attribute just maxed out, update the display timer
+			if fade_on_attribute_increase and blink_fade_at_value_max and modulate.a < 0.75:
+				# Only stop the fade and show the attribute bar if it fades while increasing
+				_stop_fade_and_show(Color(1.0, 1.0, 1.0, 0.75))
+				display_timer.wait_time = 0.5
+			else: # Fade out when maxed
+				display_timer.wait_time = 0.01 if start_fade_at_value_max else time_before_fadeout
+			display_timer.start()
+		elif fade_on_attribute_increase and display_timer.is_stopped():
+			display_timer.wait_time = time_before_fadeout
+			display_timer.start()
+
 	attribute_bar.update_value(_value_current, _value_max)
 	attribute_label.text = str(int(_value_current))
 	
-	display_timer.start()
+	last_value = _value_current
 
 
 func _on_display_timer_timeout():
-	var display_tween = create_tween().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_CUBIC).set_parallel()
+	display_tween = create_tween().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_CUBIC).set_parallel()
 	display_tween.tween_property(self,"modulate", Color.TRANSPARENT,.5)
+
+func _stop_fade_and_show(start_modulate: Color) -> void:
+	# Abort the fade
+	if display_tween and display_tween.is_running():
+		display_tween.kill()
+	# Stops the tween timer, which won't call the timeout signal
+	display_timer.stop()
+	
+	modulate = start_modulate

--- a/addons/cogito/PackedScenes/Player_HUD.tscn
+++ b/addons/cogito/PackedScenes/Player_HUD.tscn
@@ -93,11 +93,11 @@ offset_bottom = -150.0
 grow_horizontal = 2
 grow_vertical = 0
 script = ExtResource("7_gti6b")
+start_fade_at_value_max = true
+fade_on_attribute_increase = true
+blink_fade_at_value_max = true
 time_before_fadeout = 1.5
 bar_stylebox = SubResource("StyleBoxFlat_8x37p")
-
-[node name="AttributeBar" parent="FixedStaminaBar/HBoxContainer" index="1"]
-custom_minimum_size = Vector2(130, 5)
 
 [node name="AttributeLabel" parent="FixedStaminaBar/HBoxContainer" index="2"]
 visible = false


### PR DESCRIPTION
- Added the option to use floor slope to influence run exhaustion speed. This works for steps too, by comparing the player's global y position over frames.
- This behavior lerps the base run exhaustion speed to either an uphill or downhill max exhaustion speed. The idea is that running uphill should drain stamina much faster, while running downhill should drain it a bit slower, either on ramps or steps.
- Enhanced the UI stamina attribute to be a little more flexible with how it displays, including whether it fades out while the attribute increases, fades immediately upon reaching max value, and blinking back on momentarily if faded out when reaching max so the player can know it has finished recovering.
- Fixed the stamina bar to be the same width as the background, like the other attribute component bars.