### PR TITLE
Make carried object rotation more consistent

### DIFF
--- a/addons/cogito/Components/Interactions/CarryableComponent.gd
+++ b/addons/cogito/Components/Interactions/CarryableComponent.gd
@@ -88,7 +88,8 @@ func rotate_object(_delta):
 	input_dir = Input.get_vector("left", "right", "forward", "back")
 	
 	if input_dir.length() > 0:
-		var rotation_vector: Vector3 = Vector3(input_dir.y, input_dir.x, 0)
+		var rotation_basis: Basis = camera.global_basis.rotated(camera.global_basis.x, -camera.global_rotation.x)
+		var rotation_vector: Vector3 = rotation_basis * Vector3(input_dir.y, input_dir.x, 0).normalized()
 		parent_object.global_rotate(rotation_vector, deg_to_rad(rotation_speed) )
 
 


### PR DESCRIPTION
Changes carried object rotation so that it behaves consistently regardless of object's position or the rotation of the camera.  

Pressing forward will now always rotate the object away from the player, while pressing to either side will always rotate along the global y axis.