### PR TITLE
Fixed null variable Direction assignment to deal_damage

### DIFF
--- a/addons/cogito/CogitoObjects/cogito_projectile.gd
+++ b/addons/cogito/CogitoObjects/cogito_projectile.gd
@@ -106,7 +106,7 @@ func stick_to_object(collider: Node):
 	#self.angular_velocity = Vector3.ZERO
 
 func deal_damage(collider: Node,bullet_direction,bullet_position):
-	bullet_direction = Direction
+	# bullet_direction = Direction
 	CogitoGlobals.debug_log(true, "CogitoProjectile", self.name + ": dealing damage amount " + str(damage_amount) + " on collider " + collider.name + " at " + str(bullet_position) + " in direction " + str(Direction) )
 
 	collider.damage_received.emit(damage_amount,bullet_direction,bullet_position)


### PR DESCRIPTION
Fixes bug #456 by removing the variable assignment of Direction which is null to bullet_direction. The darts now destroy the targets.

Tested shooting the targets with the guns and they behave as expected.