### PR TITLE
Fixed UI inventory slot selection bug

### DIFF
--- a/addons/cogito/InventoryPD/UiScenes/Slot.gd
+++ b/addons/cogito/InventoryPD/UiScenes/Slot.gd
@@ -82,12 +82,7 @@ func _on_charge_changed():
 		charge_label.text = str(int(item_data.charge_current)) 
 
 
-func _on_gui_input(event):
-	if event is InputEventMouseButton \
-			and (event.button_index == MOUSE_BUTTON_LEFT \
-			or event.button_index == MOUSE_BUTTON_RIGHT) \
-			and event.is_pressed():
-		slot_clicked.emit(get_index(), event.button_index)
+func _on_gui_input(event: InputEvent):
 	
 	# Setting SLOT GAMPEAD INTERACTIONS HERE
 	if event.is_action_pressed("inventory_move_item"):

--- a/addons/cogito/InventoryPD/UiScenes/inventory_interface.gd
+++ b/addons/cogito/InventoryPD/UiScenes/inventory_interface.gd
@@ -157,7 +157,7 @@ func _slot_on_mouse_exit():
 
 
 func update_grabbed_slot_position():
-	#print("Inventory interface: update grabbed slot position to ", control_in_focus, " at ", control_in_focus.global_position)
+	# print("Inventory interface: update grabbed slot position to ", control_in_focus, " at ", control_in_focus.global_position)
 	grabbed_slot_node.global_position = control_in_focus.global_position + (control_in_focus.size / 2)
 
 
@@ -177,7 +177,7 @@ func set_external_inventory(_external_inventory_owner):
 	
 	inventory_data.owner = external_inventory_owner # Setting reference to external inventory owner node
 #	inventory_data.inventory_interact.connect(on_inventory_interact)
-	inventory_data.inventory_button_press.connect(on_inventory_button_press)
+	inventory_data.inventory_button_press.connect(on_inventory_button_press.bind(external_inventory_ui))
 	external_inventory_ui.inventory_name = external_inventory_owner.display_name
 	external_inventory_ui.set_inventory_data(inventory_data)
 	
@@ -212,7 +212,7 @@ func set_player_inventory_data(inventory_data : CogitoInventory):
 	
 #	inventory_data.inventory_interact.connect(on_inventory_interact)
 	if !inventory_data.inventory_button_press.is_connected(on_inventory_button_press):
-		inventory_data.inventory_button_press.connect(on_inventory_button_press)
+		inventory_data.inventory_button_press.connect(on_inventory_button_press.bind(inventory_ui))
 	inventory_ui.set_inventory_data(inventory_data)
 	if !is_using_hotbar:
 		quick_slots.show()
@@ -226,7 +226,7 @@ func set_player_inventory_data(inventory_data : CogitoInventory):
 
 
 # Inventory handling on gamepad buttons
-func on_inventory_button_press(inventory_data: CogitoInventory, index: int, action: String):
+func on_inventory_button_press(inventory_data: CogitoInventory, index: int, action: String, local_inventory_ui):
 	match [grabbed_slot_data, action]:
 		[null, "inventory_move_item"]:
 			# Check if item is being wielded before grabbing it.
@@ -280,14 +280,8 @@ func on_inventory_button_press(inventory_data: CogitoInventory, index: int, acti
 			Audio.play_sound(sound_error)
 			CogitoGlobals.debug_log(true, "inventory_interface.gd", "Can't drop while moving an item.")
 
-
-	var amount_of_inventory_slots = inventory_ui.slot_array.size()
-	var element : int
-	if index < amount_of_inventory_slots:
-		element = index
-	else:
-		element = amount_of_inventory_slots-1
-	# Should fix issues where an external inventory is bigger than the players
+	# When connecting to the signal, we have bind the inventory_ui so we can use that to set focus.
+	local_inventory_ui.slot_array[index].grab_focus()
 	update_grabbed_slot()
 
 

--- a/addons/cogito/InventoryPD/UiScenes/inventory_interface.gd
+++ b/addons/cogito/InventoryPD/UiScenes/inventory_interface.gd
@@ -288,7 +288,6 @@ func on_inventory_button_press(inventory_data: CogitoInventory, index: int, acti
 	else:
 		element = amount_of_inventory_slots-1
 	# Should fix issues where an external inventory is bigger than the players
-	inventory_ui.slot_array[element].grab_focus()
 	update_grabbed_slot()
 
 

--- a/project.godot
+++ b/project.godot
@@ -135,7 +135,7 @@ interact2={
 }
 action_primary={
 "deadzone": 0.5,
-"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":1,"position":Vector2(190, 11),"global_position":Vector2(199, 59),"factor":1.0,"button_index":1,"canceled":false,"pressed":true,"double_click":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":5,"axis_value":0.0,"script":null)
 ]
 }
@@ -153,7 +153,7 @@ inventory={
 }
 inventory_move_item={
 "deadzone": 0.5,
-"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":1,"position":Vector2(304, 12),"global_position":Vector2(313, 60),"factor":1.0,"button_index":1,"canceled":false,"pressed":true,"double_click":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":2,"pressure":0.0,"pressed":false,"script":null)
 ]
 }


### PR DESCRIPTION
Fixes #216 an inventory UI bug. Corrected the project settings input map to match the control mapping in game. I have also removed the if block for checking if the event is a mouse left or mouse right as this signal path from slot_clicked is commented out.

https://github.com/Phazorknight/Cogito/blob/d7af401da776ecfca079fcafe627b6e7b1b39566/addons/cogito/InventoryPD/UiScenes/Slot.gd#L90

https://github.com/Phazorknight/Cogito/blob/d7af401da776ecfca079fcafe627b6e7b1b39566/addons/cogito/InventoryPD/cogito_inventory.gd#L37-L38

This is commented out and there are no other places in the codebase that are connected to inventory_interact.

https://github.com/Phazorknight/Cogito/blob/d7af401da776ecfca079fcafe627b6e7b1b39566/addons/cogito/InventoryPD/UiScenes/inventory_interface.gd#L179