### PR TITLE
Spatial Prompt UI

### DIFF
--- a/addons/cogito/Components/PlayerInteractionComponent.gd
+++ b/addons/cogito/Components/PlayerInteractionComponent.gd
@@ -393,7 +393,7 @@ func set_state():
 
 func _on_interaction_raycast_interactable_seen(new_interactable) -> void:
 	interactable = new_interactable
-
+	
 
 func _on_interaction_raycast_interactable_unseen() -> void:
 	interactable = null

--- a/addons/cogito/DemoScenes/DemoPrefabs/coffee_mug.tscn
+++ b/addons/cogito/DemoScenes/DemoPrefabs/coffee_mug.tscn
@@ -67,6 +67,7 @@ contact_monitor = true
 max_contacts_reported = 4
 script = ExtResource("1_s8epx")
 cogito_name = ""
+display_name = "Mug"
 
 [node name="mug" type="MeshInstance3D" parent="."]
 mesh = SubResource("ArrayMesh_hinl8")

--- a/addons/cogito/PackedScenes/Player_HUD.tscn
+++ b/addons/cogito/PackedScenes/Player_HUD.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=39 format=3 uid="uid://0c32kepv0ahx"]
+[gd_scene load_steps=40 format=3 uid="uid://0c32kepv0ahx"]
 
 [ext_resource type="Script" uid="uid://dc3bukoacyq60" path="res://addons/cogito/Scripts/player_hud_manager.gd" id="1_0wdkf"]
 [ext_resource type="PackedScene" uid="uid://dhlrhobg5d4dj" path="res://addons/cogito/Components/UI/UI_PromptComponent.tscn" id="3_06ipe"]
@@ -19,6 +19,7 @@
 [ext_resource type="Texture2D" uid="uid://78js4558o61m" path="res://addons/cogito/Assets/Graphics/ItemIcons/Cogito_Pistol.png" id="9_1l2nt"]
 [ext_resource type="Texture2D" uid="uid://cxvxq8hy53ih5" path="res://addons/cogito/Assets/Graphics/ItemIcons/Cogito_FoamBullets.png" id="10_bnneb"]
 [ext_resource type="PackedScene" uid="uid://btf6bmlgtfk1b" path="res://addons/cogito/Components/DynamicInputIcon.tscn" id="12_jgxar"]
+[ext_resource type="Script" uid="uid://cub4sxinq8g1" path="res://addons/cogito/Scripts/cogito_prompt_ui.gd" id="13_bdq5t"]
 [ext_resource type="Script" uid="uid://by3n6q1edxunf" path="res://addons/cogito/QuestSystem/Components/ui_quest_hud.gd" id="15_kn51k"]
 [ext_resource type="PackedScene" uid="uid://dh4yhqd73trwx" path="res://addons/cogito/QuestSystem/Components/QuestEntry.tscn" id="16_qsjbq"]
 [ext_resource type="PackedScene" uid="uid://0j3gwj62g2eb" path="res://addons/cogito/Components/UI/UI_HintComponent.tscn" id="17_bidre"]
@@ -162,6 +163,8 @@ offset_left = 1110.0
 offset_top = 540.0
 offset_right = 1110.0
 offset_bottom = 540.0
+script = ExtResource("13_bdq5t")
+use_spatial_prompt = true
 
 [node name="PromptArea" type="VBoxContainer" parent="PromptUI"]
 layout_mode = 1

--- a/addons/cogito/Scripts/cogito_prompt_ui.gd
+++ b/addons/cogito/Scripts/cogito_prompt_ui.gd
@@ -1,0 +1,90 @@
+extends Control
+
+## Some margin to keep the marker away from the screen's corners.
+const MARGIN = 8
+
+@export var use_spatial_prompt : bool = false
+
+@onready var camera := get_viewport().get_camera_3d()
+@onready var parent := get_parent()
+
+
+func _process(_delta: float) -> void:
+	if !use_spatial_prompt:
+		return
+	
+	if parent.player.player_interaction_component.interactable == null:
+		return
+		
+	if not camera.current:
+		# If the camera we have isn't the current one, get the current camera.
+		camera = get_viewport().get_camera_3d()
+		
+	var parent_position: Vector3 = parent.player.player_interaction_component.interactable.global_transform.origin
+	var camera_transform := camera.global_transform
+	var camera_position := camera_transform.origin
+
+	# We would use "camera.is_position_behind(parent_position)", except
+	# that it also accounts for the near clip plane, which we don't want.
+	var is_behind := camera_transform.basis.z.dot(parent_position - camera_position) > 0
+
+	var unprojected_position := camera.unproject_position(parent_position)
+	# `get_size_override()` will return a valid size only if the stretch mode is `2d`.
+	# Otherwise, the viewport size is used directly.
+	var viewport_base_size: Vector2i = (
+			get_viewport().content_scale_size if get_viewport().content_scale_size > Vector2i(0, 0)
+			else get_viewport().size
+	)
+
+
+	# We need to handle the axes differently.
+	# For the screen's X axis, the projected position is useful to us,
+	# but we need to force it to the side if it's also behind.
+	if is_behind:
+		if unprojected_position.x < viewport_base_size.x / 2:
+			unprojected_position.x = viewport_base_size.x - MARGIN
+		else:
+			unprojected_position.x = MARGIN
+
+	# For the screen's Y axis, the projected position is NOT useful to us
+	# because we don't want to indicate to the user that they need to look
+	# up or down to see something behind them. Instead, here we approximate
+	# the correct position using difference of the X axis Euler angles
+	# (up/down rotation) and the ratio of that with the camera's FOV.
+	# This will be slightly off from the theoretical "ideal" position.
+	if is_behind or unprojected_position.x < MARGIN or \
+			unprojected_position.x > viewport_base_size.x - MARGIN:
+		var look := camera_transform.looking_at(parent_position, Vector3.UP)
+		var diff := angle_difference(look.basis.get_euler().x, camera_transform.basis.get_euler().x)
+		unprojected_position.y = viewport_base_size.y * (0.5 + (diff / deg_to_rad(camera.fov)))
+
+	position = Vector2(
+			clamp(unprojected_position.x, MARGIN, viewport_base_size.x - MARGIN),
+			clamp(unprojected_position.y, MARGIN, viewport_base_size.y - MARGIN)
+	)
+
+	#label.visible = true
+	rotation = 0
+	# Used to display a diagonal arrow when the waypoint is displayed in
+	# one of the screen corners.
+	var overflow := 0
+
+	if position.x <= MARGIN:
+		# Left overflow.
+		overflow = int(-TAU / 8.0)
+		#label.visible = false
+		rotation = TAU / 4.0
+	elif position.x >= viewport_base_size.x - MARGIN:
+		# Right overflow.
+		overflow = int(TAU / 8.0)
+		#label.visible = false
+		rotation = TAU * 3.0 / 4.0
+
+	if position.y <= MARGIN:
+		# Top overflow.
+		#label.visible = false
+		rotation = TAU / 2.0 + overflow
+	elif position.y >= viewport_base_size.y - MARGIN:
+		# Bottom overflow.
+		#label.visible = false
+		rotation = -overflow

--- a/addons/cogito/Scripts/cogito_prompt_ui.gd.uid
+++ b/addons/cogito/Scripts/cogito_prompt_ui.gd.uid
@@ -1,0 +1,1 @@
+uid://cub4sxinq8g1


### PR DESCRIPTION
Adds the option to display prompts on top of the interactable objects instead of a fixed position at the center of the screen.
Can be toggled on/off under _PlayerHUD > Prompt UI > Use spatial prompt_.

Current issues:
Currently the prompts get positioned at the origin of the interactive object. This is fine for most CogitoObjects, but is not ideal for Door etc, where the origin is usually not the center of an object.

Ideas on how to fix this:
One idea would be to get the AABB of an object and position the prompts at the center of it. This would require use to update other objects like CogitoDoors to use AABBs though. I'm open for other suggestions.

https://github.com/user-attachments/assets/c29791d6-5077-4085-a497-afbb1c420f4f


