### PR TITLE
Fix PromptUI's position to keep it at the center of the screen in different resolutions.

### DIFF
--- a/addons/cogito/PackedScenes/Player_HUD.tscn
+++ b/addons/cogito/PackedScenes/Player_HUD.tscn
@@ -162,8 +162,8 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = 40.0
-offset_right = 40.0
+offset_left = 60.0
+offset_right = 60.0
 grow_horizontal = 2
 grow_vertical = 2
 


### PR DESCRIPTION
PromptUI's positon before this change:

<img width="1278" height="725" alt="Screenshot from 2025-10-17 12-51-14" src="https://github.com/user-attachments/assets/515d2876-cf04-4296-8349-76c0d6dd3137" />

In the main branch, in Player's HUD, PromptUI's Layout Mode value is 2 but it seems this property is an internal property and shouldn't be set manually!

<img width="421" height="624" alt="Screenshot from 2025-10-17 11-38-55" src="https://github.com/user-attachments/assets/83921f7f-7524-4d08-8d13-8e8c07e2d044" />

I selected PromptUI node and from Anchor Presets pressed Center:

<img width="1118" height="419" alt="Screenshot from 2025-10-17 12-27-21" src="https://github.com/user-attachments/assets/6d3d900b-8d8f-4af3-9b36-b30ae61cc0d5" />

Result:

<img width="421" height="624" alt="Screenshot from 2025-10-17 12-11-40" src="https://github.com/user-attachments/assets/7d2f6145-4740-4bb4-836c-a8969f9c53eb" />

For objects like Fridge, text overlapped with crosshair:

<img width="1446" height="960" alt="Screenshot from 2025-10-17 12-13-57" src="https://github.com/user-attachments/assets/dc052738-d8aa-4dbc-a11f-5fd96757332b" />

I added 40 to position.x:

<img width="421" height="624" alt="Screenshot from 2025-10-17 12-12-48" src="https://github.com/user-attachments/assets/68bfd026-8044-4fe3-825a-e55c8fe53aaf" />

and this is the final result:

<img width="1289" height="758" alt="Screenshot from 2025-10-17 12-15-11" src="https://github.com/user-attachments/assets/9ae5317b-c83a-4110-9193-218031b046eb" />
