### PR TITLE
Ensure resolution slider label updates when moving to fullscreen

### DIFF
--- a/addons/cogito/EasyMenus/Scripts/OptionsTabMenu.gd
+++ b/addons/cogito/EasyMenus/Scripts/OptionsTabMenu.gd
@@ -385,7 +385,7 @@ func update_fullscreen_resolution_slider_value() -> void:
 
 func update_fullscreen_resolution_slider_label() -> void:
 	var scale = fullscreen_resolution_scale_val
-	var window_size = get_window().size
+	var window_size = DisplayServer.screen_get_size()
 	var pct = roundi(scale * 100.0)
 	var res_x = roundi(window_size.x * scale)
 	var res_y = roundi(window_size.y * scale)


### PR DESCRIPTION
Hey there! Things have been a bit busy with life stuff but I've been wanting to get back into some Cogito PRs.

This PR fixes what @mrezai mentioned [here](https://github.com/Phazorknight/Cogito/discussions/486#discussioncomment-14837496), specifically regarding the resolution slider label not updating when moving into fullscreen:

>Fullscreen works irregularly for example resolution values are out of the screen supporting range or values will be changed in the next runs. 

The actual issue was that after moving to fullscreen, the resolution label is not updated to take into account the window's / screen's fullscreen size.

To test, go to the graphics settings, and enter fullscreen mode. The resolution listed under the slider should be your native screen resolution, _not_ the resolution that was selected in windowed mode.