### PR TITLE
Allow cancelling gamepad remapping via mouse and keyboard

### DIFF
--- a/addons/cogito/EasyMenus/Components/gamepad_bind_button.gd
+++ b/addons/cogito/EasyMenus/Components/gamepad_bind_button.gd
@@ -35,28 +35,44 @@ func _input(event):
 	if !is_remapping:
 		return
 	
+	# Allow cancelling remapping with the Escape key
+	if event is InputEventKey:
+		if event.pressed and event.keycode == KEY_ESCAPE:
+			end_remapping()
+			accept_event()
+			return
+	
+	# Allow cancelling remapping with a mouse click
+	if event is InputEventMouseButton:
+		if event.pressed:
+			end_remapping()
+			accept_event()
+			return
+	
 	if event is InputEventJoypadMotion:
 		if abs(event.axis_value) > .1: # Adding threshold for joystick axis input mapping
-			InputHelper.set_joypad_input_for_action(action,event,false)
-			text = ""
-			gamepad_input_icon.visible = true
-			update_icon()
-			is_remapping = false
-			button_pressed = false
+			InputHelper.set_joypad_input_for_action(action, event, false)
+			end_remapping()
+			accept_event()
+			return
 	
 	if event is InputEventJoypadButton:
 		if event.pressed:
-			InputHelper.set_joypad_input_for_action(action,event,false)
-			text = ""
-			gamepad_input_icon.visible = true
-			update_icon()
-			is_remapping = false
-			button_pressed = false
-		
+			InputHelper.set_joypad_input_for_action(action, event, false)
+			end_remapping()
+
 	accept_event()
 
 
+# End the remapping process, resetting the binding process for the future.
+func end_remapping():
+	is_remapping = false
+	button_pressed = false
+	text = ""
+	gamepad_input_icon.visible = true
+	update_icon()
+
+
 func update_icon():
-	#text = "%s" % InputMap.action_get_events(action)[0].as_text()
 	gamepad_input_icon.action_name = action
 	gamepad_input_icon.update_input_icon()

--- a/addons/cogito/EasyMenus/Components/kbm_bind_button.gd
+++ b/addons/cogito/EasyMenus/Components/kbm_bind_button.gd
@@ -36,21 +36,26 @@ func _input(event):
 		return
 	
 	if event is InputEventJoypadMotion:
+		end_remapping()
+		accept_event()
 		return
 	
-	if event is InputEventKey || ( event is InputEventMouseButton && event.pressed):
-		InputHelper.set_keyboard_input_for_action(action,event,false)
-		text = ""
-		kbm_input_icon.visible = true
-		update_icon()
-		
-		is_remapping = false
-		button_pressed = false
+	if event is InputEventKey || (event is InputEventMouseButton && event.pressed):
+		InputHelper.set_keyboard_input_for_action(action, event, false)
+		end_remapping()
 		
 	accept_event()
 
 
+# End the remapping process, resetting the binding process for the future.
+func end_remapping():
+	is_remapping = false
+	button_pressed = false
+	text = ""
+	kbm_input_icon.visible = true
+	update_icon()
+
+
 func update_icon():
-	#text = "%s" % InputMap.action_get_events(action)[0].as_text()
 	kbm_input_icon.action_name = action
 	kbm_input_icon.update_input_icon()


### PR DESCRIPTION
Hey! In this PR, we are addressing a bug that if you accidentally try to remap a gamepad input and have no gamepad connected, you're unable to cancel the remapping. The introduced changes now allow a user to hit their Escape key, or click anywhere to cancel the remapping.

We also adjusted the keyboard remapping functionality to match the changes in the gamepad remapping functionality.

To test, try to remap a gamepad input. Hit either Escape or click with the mouse to exit the remapping.

This was originally brought up by @mrezai in https://github.com/Phazorknight/Cogito/discussions/486.